### PR TITLE
Expose per-query metrics and add CI tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ python showcase_ranker.py \
     * [Step 2: Generate Disease→Adjuvant Pairs](#step-2-generate-diseaseadjuvant-pairs-new)
     * [Step 3: Train the Recommender](#step-3-train-the-recommender)
     * [Step 4: Try the Trained Recommender](#step-4-try-the-trained-recommender)
+    * [Step 5: Compute Confidence Intervals & Non-inferiority Verdicts](#step-5-compute-confidence-intervals--non-inferiority-verdicts-new)
 * [Output Files and Results](#output-files-and-results)
 * [Expected Performance](#expected-performance)
 * [Troubleshooting](#troubleshooting)
@@ -195,14 +196,18 @@ python train_ranker.py \
 
 **Option B: Dual-head (Vaccine + Disease) recommender (NEW)**
 
-The `train_disease_ranker.py` script extends the original model with a disease→adjuvant 
-head, enabling both vaccine-based and disease-based adjuvant recommendations:
+The `train_disease_ranker.py` script extends the original model with a disease→adjuvant
+head, enabling both vaccine-based and disease-based adjuvant recommendations.
+It also materialises the vaccine-head **disease baseline** that is used for
+non-inferiority/equivalence analysis via the `--disease-baseline-aggregation`
+flag (default: `max`, alternative: `mean`).
 
 ```bash
 python train_disease_ranker.py \
     --data-path data/processed/training_samples.csv \
     --output-dir results/disease_dual_head \
     --run-name disease_v1 \
+    --disease-baseline-aggregation max \
     --split-scheme both \
     --epochs 100 \
     --batch-size 128 \
@@ -282,6 +287,56 @@ brief ontology context.
 - `--include-preclinical 1`: Include research-stage adjuvants in recommendations
 - `--route IM`: Filter by administration route (IM, IN, oral, ID)
 - `--coverage 0.9`: Use conformal prediction for calibrated top-K sets (if implemented)
+
+#### Step 5: Compute confidence intervals & non-inferiority verdicts (NEW)
+
+Training now persists **per-query metrics** for both the disease head and the
+vaccine-head-derived disease baseline (see `artifacts/results/<scheme>.json`). Use
+`src/eval_ci.py` to bootstrap confidence intervals, paired randomisation tests,
+and 90 % Δ confidence intervals for non-inferiority/equivalence checks.
+
+1. Re-run `train_disease_ranker.py` (or at least its evaluation stage) with the
+   latest code so the metrics JSON includes the new `*_per_query` payloads.
+2. Compare one or more systems by pointing the CI tool at the relevant metrics
+   files. Supply `name=/path/to/results.json` pairs via `--systems` and identify
+   the baseline using `--baseline`.
+
+Examples:
+
+```bash
+# Non-inferiority of the disease head vs vaccine baseline on the test split
+python src/eval_ci.py \
+  --systems dual_head@disease_head=artifacts/results/transductive.json \
+            vaccine_baseline@vaccine_agg=artifacts/results/transductive.json \
+  --baseline vaccine_baseline \
+  --head disease \
+  --split test \
+  --delta ndcg@10=0.02 recall@10=0.03
+
+# Compare two checkpoints (e.g., SapBERT tuned vs frozen)
+python src/eval_ci.py \
+  --systems tuned@vaccine_head=results/sapbert_tuned/results/inductive.json \
+            frozen@vaccine_head=results/sapbert_frozen/results/inductive.json \
+  --baseline frozen \
+  --head vaccine \
+  --split test \
+  --metrics ndcg@5 ndcg@10 recall@5 recall@10
+```
+
+Key options:
+
+- `--delta metric=value` sets the non-inferiority/equivalence margin (δ) per metric.
+- `--disease-baseline-aggregation` (training flag) controls how vaccine predictions
+  are aggregated to disease scores for the baseline recorded in the metrics JSON.
+- `--metrics` restricts evaluation to the listed metrics; omit it to analyse all
+  metrics shared across systems.
+- Append `@disease_head`, `@vaccine_head`, or `@vaccine_agg` to the system name in
+  `--systems` to choose which metric block to load from the JSON artefact.
+
+The tool prints tables containing bootstrap 95 % CIs for each system, paired
+randomisation p-values against the baseline, and a verdict column indicating
+whether the dual-head extension is *Equivalent*, *Non-inferior*, or *Inferior*
+under the supplied δ.
 
 ## Output Files and Results
 

--- a/README.md
+++ b/README.md
@@ -198,8 +198,10 @@ python train_ranker.py \
 
 The `train_disease_ranker.py` script extends the original model with a disease→adjuvant
 head, enabling both vaccine-based and disease-based adjuvant recommendations.
-It also materialises the vaccine-head **disease baseline** that is used for
-non-inferiority/equivalence analysis via the `--disease-baseline-aggregation`
+It now optimises an ApproxNDCG surrogate over the top-K adjuvants for each disease
+while retaining a lightly weighted ListNet term (0.2 by default) for optimisation
+stability. The run also materialises the vaccine-head **disease baseline** that is
+used for non-inferiority/equivalence analysis via the `--disease-baseline-aggregation`
 flag (default: `max`, alternative: `mean`).
 
 ```bash
@@ -220,6 +222,10 @@ python train_disease_ranker.py \
 
 **Key parameters for disease head:**
 - `--lambda-disease`: Weight for disease→adjuvant ranking loss (default: 1.0)
+- `--disease-ndcg-weight`: Multiplier on the ApproxNDCG surrogate (default: 1.0)
+- `--disease-listnet-weight`: Retained ListNet stabiliser weight (default: 0.2)
+- `--disease-ndcg-topk`: Number of adjuvants contributing to ApproxNDCG (default: 50)
+- `--disease-ndcg-tau`: Temperature of the sigmoid rank approximation (default: 1.0)
 - `--disease-batch-size`: Number of disease queries per epoch (default: 32)
 - `--gamma-mech`: Weight for mechanism-aware compatibility scoring (default: 0.3)
 - `--split-scheme`: Choose 'transductive', 'inductive', or 'both'

--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -1,0 +1,2 @@
+"""Utilities and scripts for downstream analysis and visualisation."""
+

--- a/analysis/draw_case_study_panels.py
+++ b/analysis/draw_case_study_panels.py
@@ -1,0 +1,399 @@
+"""Generate the four-panel case-study figure from exporter outputs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, List, Mapping, MutableMapping, Optional, Sequence
+
+import matplotlib
+
+# Use a non-interactive backend so the script can run on headless machines.
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+
+def _ensure_run(summary: Mapping[str, object], label: str) -> Mapping[str, object]:
+    runs = summary.get("runs")
+    if not isinstance(runs, Mapping):
+        raise KeyError("Summary JSON is missing the 'runs' mapping.")
+    run = runs.get(label)
+    if run is None:
+        available = ", ".join(sorted(map(str, runs.keys())))
+        raise KeyError(f"Run label '{label}' not found. Available labels: {available}")
+    if not isinstance(run, Mapping):
+        raise TypeError(f"Run entry for label '{label}' must be a mapping.")
+    return run
+
+
+def _sorted_topk_keys(run_metrics: Mapping[str, object]) -> List[int]:
+    topk = run_metrics.get("topk", {})
+    if not isinstance(topk, Mapping):
+        return []
+    result: List[int] = []
+    for key in topk.keys():
+        try:
+            result.append(int(key))
+        except (TypeError, ValueError):
+            continue
+    return sorted(result)
+
+
+def _plot_topk_panel(ax: plt.Axes, run_metrics: Mapping[str, object]) -> None:
+    topk_list = run_metrics.get("topk_list", [])
+    if not isinstance(topk_list, Sequence) or len(topk_list) == 0:
+        ax.text(0.5, 0.5, "No Top-10 entries available", ha="center", va="center")
+        ax.set_axis_off()
+        return
+
+    labels: List[str] = []
+    scores: List[float] = []
+    relevance: List[int] = []
+    for entry in topk_list:
+        if not isinstance(entry, Mapping):
+            continue
+        labels.append(str(entry.get("adjuvant_label", entry.get("adjuvant_id", "?"))))
+        try:
+            scores.append(float(entry.get("score", 0.0)))
+        except (TypeError, ValueError):
+            scores.append(0.0)
+        relevance.append(int(entry.get("relevance_binary", 0)))
+
+    if not labels:
+        ax.text(0.5, 0.5, "No Top-10 entries available", ha="center", va="center")
+        ax.set_axis_off()
+        return
+
+    y_positions = np.arange(len(labels))
+    colors = ["#1b9e77" if rel else "#cccccc" for rel in relevance]
+    ax.barh(y_positions, scores, color=colors)
+    ax.set_yticks(y_positions)
+    ax.set_yticklabels([f"#{rank + 1} {label}" for rank, label in enumerate(labels)])
+    ax.invert_yaxis()
+    ax.set_xlabel("Model score")
+    ax.set_title("Panel A – Top-10 ranking")
+
+    for idx, (score, rel) in enumerate(zip(scores, relevance)):
+        if rel:
+            ax.text(
+                score,
+                idx,
+                " ✓",
+                ha="left",
+                va="center",
+                color="#1b9e77",
+                fontsize=10,
+                fontweight="bold",
+            )
+
+    topk_metrics = run_metrics.get("topk", {})
+    if isinstance(topk_metrics, Mapping):
+        lines: List[str] = []
+        for k in _sorted_topk_keys(run_metrics):
+            metrics = topk_metrics.get(str(k), {})
+            if not isinstance(metrics, Mapping):
+                continue
+            precision = metrics.get("precision")
+            recall = metrics.get("recall")
+            ndcg = metrics.get("ndcg")
+            if isinstance(precision, (int, float)):
+                lines.append(f"P@{k}: {precision:.3f}")
+            if isinstance(recall, (int, float)):
+                lines.append(f"R@{k}: {recall:.3f}")
+            if isinstance(ndcg, (int, float)):
+                lines.append(f"NDCG@{k}: {ndcg:.3f}")
+        if lines:
+            ax.text(
+                0.98,
+                0.02,
+                "\n".join(lines),
+                transform=ax.transAxes,
+                ha="right",
+                va="bottom",
+                fontsize=9,
+                bbox=dict(boxstyle="round", facecolor="white", edgecolor="none", alpha=0.8),
+            )
+
+
+def _plot_dcg_panel(ax: plt.Axes, run_metrics: Mapping[str, object]) -> None:
+    dcg_curve = run_metrics.get("dcg_curve", [])
+    idcg_curve = run_metrics.get("idcg_curve", [])
+    ndcg_curve = run_metrics.get("ndcg_curve_k", [])
+    if not isinstance(dcg_curve, Sequence) or len(dcg_curve) == 0:
+        ax.text(0.5, 0.5, "No DCG data", ha="center", va="center")
+        ax.set_axis_off()
+        return
+
+    ranks = np.arange(1, len(dcg_curve) + 1)
+    ax.plot(ranks, dcg_curve, label="DCG", color="#4c72b0", marker="o")
+    if isinstance(idcg_curve, Sequence) and len(idcg_curve) == len(ranks):
+        ax.plot(ranks, idcg_curve, label="IDCG", color="#55a868", marker="s")
+    ax.set_xlabel("Rank")
+    ax.set_ylabel("Cumulative gain")
+    ax.set_title("Panel B – DCG / IDCG / NDCG")
+
+    ax2 = ax.twinx()
+    if isinstance(ndcg_curve, Sequence) and len(ndcg_curve) == len(ranks):
+        ax2.plot(ranks, ndcg_curve, label="NDCG", color="#c44e52", linestyle="--")
+        ax2.set_ylim(0, 1.05)
+        ax2.set_ylabel("NDCG")
+        final_ndcg = run_metrics.get("ndcg@curve_k")
+        if isinstance(final_ndcg, (int, float)):
+            ax2.text(
+                0.98,
+                0.05,
+                f"NDCG@{len(ranks)} = {final_ndcg:.3f}",
+                transform=ax2.transAxes,
+                ha="right",
+                va="bottom",
+                fontsize=9,
+                bbox=dict(boxstyle="round", facecolor="white", edgecolor="none", alpha=0.8),
+            )
+
+    handles, labels = ax.get_legend_handles_labels()
+    handles2, labels2 = ax2.get_legend_handles_labels()
+    if handles2:
+        handles.extend(handles2)
+        labels.extend(labels2)
+    if handles:
+        ax.legend(handles, labels, loc="upper left")
+
+
+def _plot_reliability_panel(ax: plt.Axes, run_metrics: Mapping[str, object]) -> None:
+    reliability = run_metrics.get("reliability", {})
+    bins = reliability.get("bins") if isinstance(reliability, Mapping) else None
+    mode = reliability.get("mode", "unknown") if isinstance(reliability, Mapping) else "unknown"
+    if not isinstance(bins, Sequence) or len(bins) == 0:
+        ax.text(0.5, 0.5, "Reliability data unavailable", ha="center", va="center")
+        ax.set_axis_off()
+        return
+
+    confidences: List[float] = []
+    precisions: List[float] = []
+    counts: List[int] = []
+    for entry in bins:
+        if not isinstance(entry, Mapping):
+            continue
+        confidences.append(float(entry.get("confidence", 0.0)))
+        precisions.append(float(entry.get("precision", 0.0)))
+        counts.append(int(entry.get("count", 0)))
+
+    if not confidences:
+        ax.text(0.5, 0.5, "Reliability data unavailable", ha="center", va="center")
+        ax.set_axis_off()
+        return
+
+    sizes = 30 + 5 * np.array(counts)
+    ax.plot([0, 1], [0, 1], color="#444444", linestyle="--", linewidth=1, label="Perfect calibration")
+    ax.scatter(confidences, precisions, s=sizes, color="#4c72b0", alpha=0.8, label="Bins")
+    for conf, prec, count in zip(confidences, precisions, counts):
+        ax.text(conf, prec, str(count), fontsize=8, ha="center", va="bottom")
+
+    ax.set_xlabel("Confidence")
+    ax.set_ylabel("Precision")
+    ax.set_xlim(0, 1)
+    ax.set_ylim(0, 1)
+    ax.set_title("Panel C – Reliability diagram")
+    ece = run_metrics.get("ece")
+    if isinstance(ece, (int, float)):
+        ax.text(
+            0.02,
+            0.98,
+            f"ECE = {ece:.3f}\nMode = {mode}",
+            transform=ax.transAxes,
+            ha="left",
+            va="top",
+            fontsize=9,
+            bbox=dict(boxstyle="round", facecolor="white", edgecolor="none", alpha=0.8),
+        )
+
+    ax.legend(loc="upper left")
+
+
+def _compute_rank_swaps(
+    df: pd.DataFrame, primary_label: str, baseline_label: Optional[str]
+) -> List[Dict[str, object]]:
+    if baseline_label is None:
+        return []
+    primary_col = f"rank_{primary_label}"
+    baseline_col = f"rank_{baseline_label}"
+    if primary_col not in df.columns or baseline_col not in df.columns:
+        return []
+
+    relevant = df[df.get("relevance_binary", 0) > 0]
+    swaps: List[Dict[str, object]] = []
+    for _, row in relevant.iterrows():
+        baseline_rank = row.get(baseline_col)
+        target_rank = row.get(primary_col)
+        if pd.isna(baseline_rank) or pd.isna(target_rank):
+            continue
+        baseline_rank = int(baseline_rank)
+        target_rank = int(target_rank)
+        label = row.get("adjuvant_label")
+        if pd.isna(label) or label is None or str(label).strip() == "":
+            label = row.get("adjuvant_vo_id", "Adjuvant")
+        swaps.append(
+            {
+                "label": str(label),
+                "baseline_rank": baseline_rank,
+                "target_rank": target_rank,
+                "delta": baseline_rank - target_rank,
+            }
+        )
+
+    swaps.sort(key=lambda item: (item["delta"], -item["target_rank"]), reverse=True)
+    return swaps
+
+
+def _plot_rank_swap_panel(
+    ax: plt.Axes,
+    summary: Mapping[str, object],
+    df: Optional[pd.DataFrame],
+    primary_label: str,
+    baseline_label: Optional[str],
+) -> None:
+    if df is None or baseline_label is None:
+        ax.text(0.5, 0.5, "No comparison data available", ha="center", va="center")
+        ax.set_axis_off()
+        return
+
+    swaps = _compute_rank_swaps(df, primary_label, baseline_label)
+    if not swaps:
+        ax.text(0.5, 0.5, "No relevant adjuvants with baseline ranks", ha="center", va="center")
+        ax.set_axis_off()
+        return
+
+    labels = [item["label"] for item in swaps]
+    deltas = [item["delta"] for item in swaps]
+    y_positions = np.arange(len(labels))
+    colours = ["#1b9e77" if delta > 0 else ("#d95f02" if delta < 0 else "#7570b3") for delta in deltas]
+
+    ax.barh(y_positions, deltas, color=colours)
+    ax.set_yticks(y_positions)
+    ax.set_yticklabels(labels)
+    ax.set_xlabel("Δ rank (baseline − target)")
+    ax.axvline(0, color="#444444", linewidth=1)
+    ax.invert_yaxis()
+    ax.set_title("Panel D – Rank swap ablation")
+
+    for idx, delta in enumerate(deltas):
+        ax.text(
+            delta,
+            idx,
+            f" {delta:+d}",
+            ha="left" if delta >= 0 else "right",
+            va="center",
+            color="black",
+        )
+
+    delta_ndcg = summary.get("delta_ndcg")
+    if isinstance(delta_ndcg, Mapping) and delta_ndcg:
+        lines = [f"{key}: {value:+.3f}" for key, value in sorted(delta_ndcg.items())]
+        ax.text(
+            0.98,
+            0.02,
+            "\n".join(lines),
+            transform=ax.transAxes,
+            ha="right",
+            va="bottom",
+            fontsize=9,
+            bbox=dict(boxstyle="round", facecolor="white", edgecolor="none", alpha=0.8),
+        )
+
+
+def create_case_study_panels(
+    summary_path: Path,
+    output_path: Path,
+    candidates_csv: Optional[Path] = None,
+    primary_label: str = "target",
+    baseline_label: Optional[str] = "baseline",
+) -> Path:
+    with Path(summary_path).open("r", encoding="utf-8") as handle:
+        summary = json.load(handle)
+    if not isinstance(summary, MutableMapping):
+        raise TypeError("Summary JSON must contain a mapping at the top level.")
+
+    run_metrics = _ensure_run(summary, primary_label)
+    if baseline_label is not None:
+        try:
+            _ensure_run(summary, baseline_label)
+        except KeyError:
+            baseline_label = None
+
+    df: Optional[pd.DataFrame] = None
+    if candidates_csv is not None and Path(candidates_csv).exists():
+        df = pd.read_csv(candidates_csv)
+
+    fig, axes = plt.subplots(2, 2, figsize=(11, 8.5))
+    ax_topk, ax_dcg, ax_rel, ax_rank = axes.flatten()
+
+    _plot_topk_panel(ax_topk, run_metrics)
+    _plot_dcg_panel(ax_dcg, run_metrics)
+    _plot_reliability_panel(ax_rel, run_metrics)
+    _plot_rank_swap_panel(ax_rank, summary, df, primary_label, baseline_label)
+
+    disease = summary.get("disease_key", "Unknown disease")
+    fig.suptitle(f"Case study panels – {disease}")
+    fig.tight_layout(rect=(0, 0, 1, 0.96))
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output_path, dpi=300)
+    plt.close(fig)
+    return output_path
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--summary-json",
+        type=Path,
+        required=True,
+        help="Metrics summary JSON produced by export_case_study.py",
+    )
+    parser.add_argument(
+        "--candidates-csv",
+        type=Path,
+        default=None,
+        help="Candidate table CSV produced by export_case_study.py",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="Destination image path (PNG, PDF, etc.)",
+    )
+    parser.add_argument(
+        "--primary-label",
+        type=str,
+        default="target",
+        help="Label of the primary run inside the summary JSON",
+    )
+    parser.add_argument(
+        "--baseline-label",
+        type=str,
+        default="baseline",
+        help="Optional label of the comparison run for Panel D",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    baseline_label: Optional[str] = args.baseline_label
+    if baseline_label is not None and baseline_label.strip() == "":
+        baseline_label = None
+    create_case_study_panels(
+        summary_path=args.summary_json,
+        output_path=args.output,
+        candidates_csv=args.candidates_csv,
+        primary_label=args.primary_label,
+        baseline_label=baseline_label,
+    )
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/disease_head_utils.py
+++ b/src/disease_head_utils.py
@@ -251,7 +251,10 @@ def _approx_ndcg_loss(scores: Tensor, gains: Tensor, tau: float = 1.0) -> Tensor
     # rank_i ≈ 1 + Σ_j sigmoid((s_j - s_i) / τ)
     diff = (scores.unsqueeze(0) - scores.unsqueeze(1)) / tau
     pairwise = torch.sigmoid(diff)
-    pairwise.fill_diagonal_(0.0)
+    mask = torch.ones_like(pairwise) - torch.eye(
+        pairwise.size(0), device=pairwise.device, dtype=pairwise.dtype
+    )
+    pairwise = pairwise * mask
     approx_rank = 1.0 + pairwise.sum(dim=1)
 
     discounts = torch.log2(approx_rank + 1.0).reciprocal()

--- a/src/disease_head_utils.py
+++ b/src/disease_head_utils.py
@@ -14,6 +14,7 @@ from typing import Dict, List, Mapping, Optional, Sequence, Set, Tuple
 import pandas as pd
 import torch
 from torch import Tensor
+import torch.nn.functional as F
 
 
 def load_disease_positives(
@@ -240,57 +241,129 @@ def build_vo_class_lookup(
     return vo_class_lookup
 
 
+def _approx_ndcg_loss(scores: Tensor, gains: Tensor, tau: float = 1.0) -> Tensor:
+    """Return ``1 - ApproxNDCG`` for the provided ``scores`` and ``gains``."""
+
+    if gains.sum() <= 0:
+        return scores.new_zeros(())
+
+    # Pairwise sigmoid approximation of the rank ("soft" rank)
+    # rank_i ≈ 1 + Σ_j sigmoid((s_j - s_i) / τ)
+    diff = (scores.unsqueeze(0) - scores.unsqueeze(1)) / tau
+    pairwise = torch.sigmoid(diff)
+    pairwise.fill_diagonal_(0.0)
+    approx_rank = 1.0 + pairwise.sum(dim=1)
+
+    discounts = torch.log2(approx_rank + 1.0).reciprocal()
+    approx_dcg = (gains * discounts).sum()
+
+    # Ideal DCG computed on sorted gains for the same slate length
+    ideal_gains = torch.sort(gains, descending=True).values
+    positions = torch.arange(
+        2, gains.numel() + 2, device=gains.device, dtype=gains.dtype
+    )
+    ideal_discounts = torch.log2(positions).reciprocal()
+    ideal_dcg = (ideal_gains * ideal_discounts).sum()
+
+    if ideal_dcg.item() <= 0:
+        return scores.new_zeros(())
+
+    ndcg = approx_dcg / ideal_dcg.clamp_min(1e-9)
+    return (1.0 - ndcg).clamp_min(0.0)
+
+
+def disease_ranking_losses(
+    embeddings: Mapping[str, Tensor],
+    disease_batch: Sequence[Dict[str, object]],
+    dual_ranker: torch.nn.Module,
+    device: torch.device,
+    *,
+    ndcg_tau: float = 1.0,
+    ndcg_topk: Optional[int] = None,
+) -> Tuple[Tensor, Tensor]:
+    """Compute ApproxNDCG and ListNet losses for a disease batch."""
+
+    if not disease_batch:
+        zero = torch.tensor(0.0, device=device)
+        return zero, zero
+
+    ndcg_losses: List[Tensor] = []
+    listnet_losses: List[Tensor] = []
+
+    for item in disease_batch:
+        pos_indices: Sequence[int] = item["pos_indices"]
+        if not pos_indices:
+            continue
+
+        candidate_indices: List[int] = list(pos_indices) + list(item["neg_indices"])
+        if not candidate_indices:
+            continue
+
+        d_idx = int(item["disease_idx"])
+        h_dis = embeddings["disease"][d_idx].unsqueeze(0)
+        h_adj = embeddings["adjuvant"][candidate_indices].unsqueeze(0)
+
+        scores = dual_ranker.score_dis(h_dis, h_adj).squeeze(0)
+        num_candidates = scores.numel()
+        num_pos = len(pos_indices)
+
+        if num_candidates == 0 or num_pos == 0:
+            continue
+
+        target_dist = scores.new_zeros(num_candidates)
+        target_dist[:num_pos] = 1.0 / num_pos
+        log_probs = F.log_softmax(scores, dim=0)
+        listnet_losses.append(-(target_dist * log_probs).sum())
+
+        gains = scores.new_zeros(num_candidates)
+        gains[:num_pos] = 1.0
+
+        if ndcg_topk is not None:
+            k = min(int(ndcg_topk), num_candidates)
+        else:
+            k = num_candidates
+
+        if k <= 0:
+            continue
+
+        if k < num_candidates:
+            top_scores, top_indices = torch.topk(scores, k=k)
+            top_gains = gains[top_indices]
+        else:
+            top_scores = scores
+            top_gains = gains
+
+        ndcg_losses.append(_approx_ndcg_loss(top_scores, top_gains, tau=ndcg_tau))
+
+    if not ndcg_losses and not listnet_losses:
+        zero = torch.tensor(0.0, device=device)
+        return zero, zero
+
+    ndcg_mean = (
+        torch.stack(ndcg_losses).mean() if ndcg_losses else torch.tensor(0.0, device=device)
+    )
+    listnet_mean = (
+        torch.stack(listnet_losses).mean()
+        if listnet_losses
+        else torch.tensor(0.0, device=device)
+    )
+    return ndcg_mean, listnet_mean
+
+
 def listnet_loss_disease(
     embeddings: Mapping[str, Tensor],
     disease_batch: Sequence[Dict[str, object]],
     dual_ranker: torch.nn.Module,
     device: torch.device,
 ) -> Tensor:
-    """
-    Compute ListNet ranking loss for disease→adjuvant queries.
-    
-    Args:
-        embeddings: {node_type: embeddings_tensor}
-        disease_batch: List of {disease_idx, pos_indices, neg_indices}
-        dual_ranker: DualRanker model with score_dis() method
-        device: torch device
-    
-    Returns:
-        Scalar loss tensor
-    """
-    if not disease_batch:
-        return torch.tensor(0.0, device=device)
-    
-    batch_losses = []
-    
-    for item in disease_batch:
-        d_idx = item['disease_idx']
-        pos_indices = item['pos_indices']
-        neg_indices = item['neg_indices']
-        
-        # Combine positives and negatives
-        candidate_indices = pos_indices + neg_indices
-        num_pos = len(pos_indices)
-        num_candidates = len(candidate_indices)
-        
-        # Get disease embedding (single query)
-        h_dis = embeddings["disease"][d_idx].unsqueeze(0)  # [1, H]
-        
-        # Get adjuvant embeddings (all candidates)
-        h_adj = embeddings["adjuvant"][candidate_indices]  # [K, H]
-        h_adj = h_adj.unsqueeze(0)  # [1, K, H]
-        
-        # Score using disease head
-        scores = dual_ranker.score_dis(h_dis, h_adj).squeeze(0)  # [K]
-        
-        # Build target distribution (uniform over positives, zero over negatives)
-        target_dist = torch.zeros(num_candidates, device=device)
-        target_dist[:num_pos] = 1.0 / num_pos
-        
-        # ListNet loss
-        log_probs = torch.nn.functional.log_softmax(scores, dim=0)
-        loss = -(target_dist * log_probs).sum()
-        
-        batch_losses.append(loss)
-    
-    return torch.stack(batch_losses).mean() if batch_losses else torch.tensor(0.0, device=device)
+    """Backward-compatible wrapper returning only the ListNet loss."""
+
+    _, listnet_loss = disease_ranking_losses(
+        embeddings,
+        disease_batch,
+        dual_ranker,
+        device,
+        ndcg_tau=1.0,
+        ndcg_topk=0,
+    )
+    return listnet_loss

--- a/src/disease_head_utils.py
+++ b/src/disease_head_utils.py
@@ -283,6 +283,7 @@ def disease_ranking_losses(
     *,
     ndcg_tau: float = 1.0,
     ndcg_topk: Optional[int] = None,
+    adjuvant_mechanism: Optional[Tensor] = None,
 ) -> Tuple[Tensor, Tensor]:
     """Compute ApproxNDCG and ListNet losses for a disease batch."""
 
@@ -306,7 +307,10 @@ def disease_ranking_losses(
         h_dis = embeddings["disease"][d_idx].unsqueeze(0)
         h_adj = embeddings["adjuvant"][candidate_indices].unsqueeze(0)
 
-        scores = dual_ranker.score_dis(h_dis, h_adj).squeeze(0)
+        mech_vec = None
+        if adjuvant_mechanism is not None and adjuvant_mechanism.numel() > 0:
+            mech_vec = adjuvant_mechanism[candidate_indices].unsqueeze(0)
+        scores = dual_ranker.score_dis(h_dis, h_adj, mech_vec).squeeze(0)
         num_candidates = scores.numel()
         num_pos = len(pos_indices)
 
@@ -358,6 +362,7 @@ def listnet_loss_disease(
     disease_batch: Sequence[Dict[str, object]],
     dual_ranker: torch.nn.Module,
     device: torch.device,
+    adjuvant_mechanism: Optional[Tensor] = None,
 ) -> Tensor:
     """Backward-compatible wrapper returning only the ListNet loss."""
 
@@ -368,5 +373,6 @@ def listnet_loss_disease(
         device,
         ndcg_tau=1.0,
         ndcg_topk=0,
+        adjuvant_mechanism=adjuvant_mechanism,
     )
     return listnet_loss

--- a/src/eval_ci.py
+++ b/src/eval_ci.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+from collections.abc import Mapping as MappingABC
 from typing import Dict, List, Mapping, Sequence
 
 import numpy as np
@@ -94,16 +95,41 @@ def load_per_query_metrics(
     try:
         payload = json.loads(raw_text)
     except json.JSONDecodeError as exc:
-        hint = ""
-        lines = [line for line in raw_text.splitlines() if line.strip()]
-        if path.suffix == ".jsonl" or all(line.lstrip().startswith("{") for line in lines[:3]):
-            hint = (
-                " Detected a JSON Lines file; pass the aggregate metrics JSON "
-                "(e.g., artifacts/results/<scheme>.json) instead."
-            )
-        raise ValueError(
-            f"Failed to parse metrics file {path}: {exc}.{hint}"
-        ) from exc
+        # Fall back to JSON Lines: take the last record containing the per-query key.
+        records: List[Mapping[str, object]] = []
+        for line in raw_text.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                records = []
+                break
+            records.append(record)
+
+        payload = None
+        if records:
+            for record in reversed(records):
+                if isinstance(record, MappingABC) and per_query_key in record:
+                    payload = record
+                    break
+
+        if payload is None:
+            hint = ""
+            lines = [line for line in raw_text.splitlines() if line.strip()]
+            if path.suffix == ".jsonl" or all(
+                line.lstrip().startswith("{") for line in lines[:3]
+            ):
+                hint = (
+                    " Detected a JSON Lines file but none of the entries contained "
+                    f"'{per_query_key}'. Pass the aggregate metrics JSON (e.g., "
+                    "artifacts/results/<scheme>.json) or regenerate metrics with per-query "
+                    "payloads."
+                )
+            raise ValueError(
+                f"Failed to parse metrics file {path}: {exc}.{hint}"
+            ) from exc
 
     if per_query_key not in payload:
         available = ", ".join(sorted(payload.keys()))

--- a/src/eval_ci.py
+++ b/src/eval_ci.py
@@ -1,14 +1,41 @@
-"""Compute bootstrap confidence intervals and paired randomization tests."""
+"""Compute CIs, paired tests, and non-inferiority verdicts for stored metrics."""
 
 from __future__ import annotations
 
 import argparse
 import json
+from dataclasses import dataclass
 from pathlib import Path
 from collections.abc import Mapping as MappingABC
 from typing import Dict, List, Mapping, Sequence
 
 import numpy as np
+
+
+def spawn_rng(master: np.random.Generator) -> np.random.Generator:
+    """Derive a child generator from ``master`` for reproducibility."""
+
+    return np.random.default_rng(master.integers(0, 2**63))
+
+
+def bootstrap_mean_distribution(
+    per_query_scores: Sequence[float],
+    *,
+    iterations: int,
+    rng: np.random.Generator,
+) -> np.ndarray:
+    """Return bootstrap distribution of the mean for ``per_query_scores``."""
+
+    scores = np.asarray(per_query_scores, dtype=float)
+    if scores.size == 0:
+        raise ValueError("Cannot bootstrap confidence interval without scores")
+
+    boot_means = np.empty(iterations, dtype=float)
+    n = scores.size
+    for i in range(iterations):
+        indices = rng.integers(0, n, size=n)
+        boot_means[i] = float(scores[indices].mean())
+    return boot_means
 
 
 def percentile_bootstrap_ci(
@@ -20,15 +47,9 @@ def percentile_bootstrap_ci(
 ) -> tuple[float, float]:
     """Return percentile bootstrap confidence interval for the mean."""
 
-    scores = np.asarray(per_query_scores, dtype=float)
-    if scores.size == 0:
-        raise ValueError("Cannot bootstrap confidence interval without scores")
-
-    boot_means = np.empty(iterations, dtype=float)
-    n = scores.size
-    for i in range(iterations):
-        indices = rng.integers(0, n, size=n)
-        boot_means[i] = float(scores[indices].mean())
+    boot_means = bootstrap_mean_distribution(
+        per_query_scores, iterations=iterations, rng=rng
+    )
     lo, hi = np.percentile(
         boot_means,
         [100 * alpha / 2.0, 100 * (1.0 - alpha / 2.0)],
@@ -64,30 +85,127 @@ def paired_randomization_test(
     return observed, float(p_value)
 
 
-def parse_system_specs(specs: Sequence[str]) -> List[tuple[str, Path]]:
-    parsed: List[tuple[str, Path]] = []
+@dataclass(frozen=True)
+class SystemSpec:
+    name: str
+    variant: str
+    path: Path
+
+
+def parse_system_specs(specs: Sequence[str]) -> List[SystemSpec]:
+    parsed: List[SystemSpec] = []
     for spec in specs:
         if "=" not in spec:
             raise ValueError(
                 f"System specification '{spec}' must be of the form name=/path/to/results.json"
             )
-        name, path_str = spec.split("=", 1)
+        raw_name, path_str = spec.split("=", 1)
+        if "@" in raw_name:
+            name, variant = raw_name.split("@", 1)
+            variant = variant or "default"
+        else:
+            name, variant = raw_name, "default"
+        name = name.strip()
+        variant = variant.strip() or "default"
+        if not name:
+            raise ValueError(f"System specification '{spec}' is missing a system name")
         path = Path(path_str)
         if not path.exists():
             raise FileNotFoundError(f"Metrics file not found: {path}")
-        parsed.append((name, path))
+        parsed.append(SystemSpec(name=name, variant=variant, path=path))
     return parsed
+
+
+def resolve_metric_prefix(head: str, variant: str) -> tuple[str, str]:
+    """Return metric prefix and canonical variant for ``head``/``variant``."""
+
+    normalised = variant.replace("-", "_").lower()
+    if head == "vaccine":
+        aliases = {
+            "default": "vaccine_head",
+            "vaccine": "vaccine_head",
+            "vaccine_head": "vaccine_head",
+        }
+        canonical = aliases.get(normalised)
+        if canonical:
+            return "ranking", canonical
+        raise ValueError(
+            f"Unsupported variant '{variant}' for head '{head}'. "
+            "Valid options: 'vaccine_head'."
+        )
+
+    aliases = {
+        "default": "disease_head",
+        "disease": "disease_head",
+        "disease_head": "disease_head",
+        "head": "disease_head",
+        "vaccine_agg": "vaccine_agg",
+        "vaccineagg": "vaccine_agg",
+        "vaccine_agg_baseline": "vaccine_agg",
+        "baseline": "vaccine_agg",
+        "vaccine_baseline": "vaccine_agg",
+    }
+    canonical = aliases.get(normalised)
+    if canonical == "disease_head":
+        return "disease_ranking", canonical
+    if canonical == "vaccine_agg":
+        return "disease_from_vaccine", canonical
+    raise ValueError(
+        f"Unsupported variant '{variant}' for head '{head}'. Valid options: "
+        "'disease_head' (default) or 'vaccine_agg'."
+    )
+
+
+def parse_delta_specs(delta_specs: Sequence[str]) -> Dict[str, float]:
+    margins: Dict[str, float] = {}
+    for spec in delta_specs:
+        if "=" not in spec:
+            raise ValueError(
+                f"Delta specification '{spec}' must be of the form metric=value"
+            )
+        metric, value = spec.split("=", 1)
+        metric = metric.strip()
+        if not metric:
+            raise ValueError(f"Delta specification '{spec}' is missing a metric name")
+        try:
+            margins[metric] = float(value)
+        except ValueError as exc:  # pragma: no cover - defensive parsing
+            raise ValueError(
+                f"Delta specification '{spec}' has a non-numeric value"
+            ) from exc
+    return margins
+
+
+def classify_equivalence(
+    ci90_lo: float,
+    ci90_hi: float,
+    lower_95: float,
+    delta: float,
+) -> str:
+    """Return textual verdict for non-inferiority/equivalence tests."""
+
+    margin = abs(delta)
+    if ci90_lo > -margin and ci90_hi < margin:
+        verdict = "Equivalent"
+    elif lower_95 > -margin:
+        verdict = "Non-inferior"
+    elif ci90_hi < -margin:
+        verdict = "Inferior"
+    elif ci90_lo > margin:
+        verdict = "Superior"
+    else:
+        verdict = "Inconclusive"
+    return f"{verdict} (δ={margin:.4f})"
 
 
 def load_per_query_metrics(
     path: Path,
     *,
-    head: str,
+    metric_prefix: str,
     split: str,
 ) -> tuple[Dict[str, Dict[str, float]], Mapping[str, float]]:
-    prefix = "ranking" if head == "vaccine" else "disease_ranking"
-    per_query_key = f"{prefix}_{split}_per_query"
-    macro_key = f"{prefix}_{split}"
+    per_query_key = f"{metric_prefix}_{split}_per_query"
+    macro_key = f"{metric_prefix}_{split}"
 
     with path.open("r", encoding="utf-8") as handle:
         raw_text = handle.read()
@@ -234,6 +352,18 @@ def build_arg_parser() -> argparse.ArgumentParser:
         help="Significance level for CIs and star annotations",
     )
     parser.add_argument(
+        "--equivalence-alpha",
+        type=float,
+        default=0.10,
+        help="Two-sided alpha for equivalence (e.g., 0.10 yields a 90% CI on Δ)",
+    )
+    parser.add_argument(
+        "--delta",
+        nargs="*",
+        default=[],
+        help="Non-inferiority/equivalence margins per metric (e.g., ndcg@10=0.02)",
+    )
+    parser.add_argument(
         "--seed",
         type=int,
         default=13,
@@ -247,16 +377,23 @@ def main() -> None:
     args = parser.parse_args()
 
     specs = parse_system_specs(args.systems)
-    system_order = [name for name, _ in specs]
+    system_order = [spec.name for spec in specs]
     if args.baseline not in system_order:
         raise ValueError("--baseline must match one of the provided system names")
 
+    delta_margins = parse_delta_specs(args.delta)
+
     per_query_data: Dict[str, Dict[str, Dict[str, float]]] = {}
     macro_data: Dict[str, Mapping[str, float]] = {}
-    for name, path in specs:
-        per_query, macro = load_per_query_metrics(path, head=args.head, split=args.split)
-        per_query_data[name] = per_query
-        macro_data[name] = macro
+    system_variants: Dict[str, str] = {}
+    for spec in specs:
+        prefix, canonical_variant = resolve_metric_prefix(args.head, spec.variant)
+        per_query, macro = load_per_query_metrics(
+            spec.path, metric_prefix=prefix, split=args.split
+        )
+        per_query_data[spec.name] = per_query
+        macro_data[spec.name] = macro
+        system_variants[spec.name] = canonical_variant
 
     baseline_macro = macro_data[args.baseline]
 
@@ -277,9 +414,12 @@ def main() -> None:
 
     rng_master = np.random.default_rng(args.seed)
 
+    system_descriptions = [
+        f"{name} ({system_variants.get(name, 'n/a')})" for name in system_order
+    ]
     print(
         f"Split: {args.split} | Head: {args.head} | Baseline: {args.baseline} | Systems: "
-        f"{', '.join(system_order)}"
+        f"{', '.join(system_descriptions)}"
     )
     print()
 
@@ -299,40 +439,85 @@ def main() -> None:
 
         baseline_values = metric_arrays[args.baseline]
         baseline_mean = float(baseline_values.mean())
-        baseline_ci_lo, baseline_ci_hi = percentile_bootstrap_ci(
+        baseline_boot = bootstrap_mean_distribution(
             baseline_values,
             iterations=args.bootstrap,
-            alpha=args.alpha,
-            rng=np.random.default_rng(rng_master.integers(0, 2**32)),
+            rng=spawn_rng(rng_master),
+        )
+        baseline_ci_lo, baseline_ci_hi = np.percentile(
+            baseline_boot,
+            [100 * args.alpha / 2.0, 100 * (1.0 - args.alpha / 2.0)],
         )
 
         print(f"Metric: {metric} (n={n_queries})")
-        print(f"{'System':<20}{'Mean':>12}{'95% CI':>20}{('Δ vs ' + args.baseline):>18}{'p-value':>12}")
+        print(
+            f"{'System':<20}{'Mean':>12}{'95% CI':>20}{('Δ vs ' + args.baseline):>18}"
+            f"{'90% CI(Δ)':>18}{'95% LB(Δ)':>15}{'Verdict (δ)':>20}{'p-value':>12}"
+        )
 
         for name in system_order:
             values = metric_arrays[name]
             mean = float(values.mean())
-            ci_lo, ci_hi = percentile_bootstrap_ci(
+            boot = bootstrap_mean_distribution(
                 values,
                 iterations=args.bootstrap,
-                alpha=args.alpha,
-                rng=np.random.default_rng(rng_master.integers(0, 2**32)),
+                rng=spawn_rng(rng_master),
+            )
+            ci_lo, ci_hi = np.percentile(
+                boot,
+                [100 * args.alpha / 2.0, 100 * (1.0 - args.alpha / 2.0)],
             )
             ci_str = format_ci(ci_lo, ci_hi)
             if name == args.baseline:
                 diff_str = f"{0.0:+.4f}"
+                ci90_str = "-"
+                lb95_str = "-"
+                verdict_str = "-"
                 p_str = "-"
             else:
-                diff, p_value = paired_randomization_test(
+                diffs = values - baseline_values
+                diff = float(diffs.mean())
+                diff_boot = bootstrap_mean_distribution(
+                    diffs,
+                    iterations=args.bootstrap,
+                    rng=spawn_rng(rng_master),
+                )
+                ci90_bounds = np.percentile(
+                    diff_boot,
+                    [
+                        100 * args.equivalence_alpha / 2.0,
+                        100 * (1.0 - args.equivalence_alpha / 2.0),
+                    ],
+                )
+                lower_95 = float(np.percentile(diff_boot, args.alpha * 100))
+                diff_rand, p_value = paired_randomization_test(
                     values,
                     baseline_values,
                     iterations=args.permutations,
-                    rng=np.random.default_rng(rng_master.integers(0, 2**32)),
+                    rng=spawn_rng(rng_master),
                 )
+                # paired_randomization_test returns the observed mean difference;
+                # ensure consistency with bootstrap-based mean.
+                if abs(diff_rand - diff) > 1e-6:
+                    diff = diff_rand
                 diff_str = f"{diff:+.4f}"
+                ci90_str = format_ci(float(ci90_bounds[0]), float(ci90_bounds[1]))
+                lb95_str = f"{lower_95:.4f}"
+                if metric in delta_margins:
+                    verdict_str = classify_equivalence(
+                        float(ci90_bounds[0]),
+                        float(ci90_bounds[1]),
+                        lower_95,
+                        delta_margins[metric],
+                    )
+                else:
+                    verdict_str = "δ not set"
                 p_str = format_p_value(p_value, args.alpha)
 
-            print(f"{name:<20}{mean:>12.4f}{ci_str:>20}{diff_str:>18}{p_str:>12}")
+            print(
+                f"{name:<20}{mean:>12.4f}{ci_str:>20}{diff_str:>18}{ci90_str:>18}"
+                f"{lb95_str:>15}{verdict_str:>20}{p_str:>12}"
+            )
 
         if metric in baseline_macro:
             macro_mean = float(baseline_macro[metric])

--- a/src/eval_ci.py
+++ b/src/eval_ci.py
@@ -89,7 +89,21 @@ def load_per_query_metrics(
     macro_key = f"{prefix}_{split}"
 
     with path.open("r", encoding="utf-8") as handle:
-        payload = json.load(handle)
+        raw_text = handle.read()
+
+    try:
+        payload = json.loads(raw_text)
+    except json.JSONDecodeError as exc:
+        hint = ""
+        lines = [line for line in raw_text.splitlines() if line.strip()]
+        if path.suffix == ".jsonl" or all(line.lstrip().startswith("{") for line in lines[:3]):
+            hint = (
+                " Detected a JSON Lines file; pass the aggregate metrics JSON "
+                "(e.g., artifacts/results/<scheme>.json) instead."
+            )
+        raise ValueError(
+            f"Failed to parse metrics file {path}: {exc}.{hint}"
+        ) from exc
 
     if per_query_key not in payload:
         available = ", ".join(sorted(payload.keys()))

--- a/src/eval_ci.py
+++ b/src/eval_ci.py
@@ -260,6 +260,13 @@ def main() -> None:
 
     baseline_macro = macro_data[args.baseline]
 
+    if len(system_order) == 1:
+        print(
+            "[info] Only one system provided. Add more entries to --systems to compare "
+            "against the baseline and run paired randomization tests."
+        )
+        print()
+
     if args.metrics:
         metrics_to_use = args.metrics
     else:

--- a/src/eval_ci.py
+++ b/src/eval_ci.py
@@ -1,0 +1,302 @@
+"""Compute bootstrap confidence intervals and paired randomization tests."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, List, Mapping, Sequence
+
+import numpy as np
+
+
+def percentile_bootstrap_ci(
+    per_query_scores: Sequence[float],
+    *,
+    iterations: int,
+    alpha: float,
+    rng: np.random.Generator,
+) -> tuple[float, float]:
+    """Return percentile bootstrap confidence interval for the mean."""
+
+    scores = np.asarray(per_query_scores, dtype=float)
+    if scores.size == 0:
+        raise ValueError("Cannot bootstrap confidence interval without scores")
+
+    boot_means = np.empty(iterations, dtype=float)
+    n = scores.size
+    for i in range(iterations):
+        indices = rng.integers(0, n, size=n)
+        boot_means[i] = float(scores[indices].mean())
+    lo, hi = np.percentile(
+        boot_means,
+        [100 * alpha / 2.0, 100 * (1.0 - alpha / 2.0)],
+    )
+    return float(lo), float(hi)
+
+
+def paired_randomization_test(
+    system_scores: Sequence[float],
+    baseline_scores: Sequence[float],
+    *,
+    iterations: int,
+    rng: np.random.Generator,
+) -> tuple[float, float]:
+    """Return mean difference and paired randomization p-value."""
+
+    system = np.asarray(system_scores, dtype=float)
+    baseline = np.asarray(baseline_scores, dtype=float)
+    if system.shape != baseline.shape:
+        raise ValueError("Scores must share shape for paired randomization test")
+
+    diffs = system - baseline
+    observed = float(diffs.mean())
+    n = diffs.size
+    ge = 0
+    for _ in range(iterations):
+        signs = rng.integers(0, 2, size=n, dtype=np.int8)
+        signs = np.where(signs == 0, -1.0, 1.0)
+        sampled = float((diffs * signs).mean())
+        if abs(sampled) >= abs(observed):
+            ge += 1
+    p_value = (ge + 1) / (iterations + 1)
+    return observed, float(p_value)
+
+
+def parse_system_specs(specs: Sequence[str]) -> List[tuple[str, Path]]:
+    parsed: List[tuple[str, Path]] = []
+    for spec in specs:
+        if "=" not in spec:
+            raise ValueError(
+                f"System specification '{spec}' must be of the form name=/path/to/results.json"
+            )
+        name, path_str = spec.split("=", 1)
+        path = Path(path_str)
+        if not path.exists():
+            raise FileNotFoundError(f"Metrics file not found: {path}")
+        parsed.append((name, path))
+    return parsed
+
+
+def load_per_query_metrics(
+    path: Path,
+    *,
+    head: str,
+    split: str,
+) -> tuple[Dict[str, Dict[str, float]], Mapping[str, float]]:
+    prefix = "ranking" if head == "vaccine" else "disease_ranking"
+    per_query_key = f"{prefix}_{split}_per_query"
+    macro_key = f"{prefix}_{split}"
+
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+
+    if per_query_key not in payload:
+        available = ", ".join(sorted(payload.keys()))
+        raise KeyError(
+            f"Key '{per_query_key}' not found in {path}. Available keys: {available}"
+        )
+
+    raw_per_query: Mapping[str, Mapping[str, float]] = payload[per_query_key]
+    per_query: Dict[str, Dict[str, float]] = {}
+    for query_id, metrics in raw_per_query.items():
+        per_query[str(query_id)] = {metric: float(value) for metric, value in metrics.items()}
+
+    macro_metrics: Mapping[str, float] = {
+        metric: float(value) for metric, value in payload.get(macro_key, {}).items()
+    }
+    return per_query, macro_metrics
+
+
+def intersect_metric_names(per_query_data: Mapping[str, Dict[str, float]]) -> set[str]:
+    names: set[str] = set()
+    for metrics in per_query_data.values():
+        if not names:
+            names = set(metrics.keys())
+        else:
+            names &= set(metrics.keys())
+    return names
+
+
+def common_query_ids(
+    systems: Mapping[str, Dict[str, Dict[str, float]]],
+    metric: str,
+) -> List[str]:
+    shared: set[str] | None = None
+    for per_query in systems.values():
+        present = {qid for qid, metrics in per_query.items() if metric in metrics}
+        shared = present if shared is None else shared & present
+    if not shared:
+        raise ValueError(f"No common queries contain metric '{metric}' across systems")
+    return sorted(shared)
+
+
+def format_ci(lo: float, hi: float) -> str:
+    return f"[{lo:.4f}, {hi:.4f}]"
+
+
+def format_p_value(p: float, alpha: float) -> str:
+    stars = ""
+    if p < 0.01:
+        stars = "**"
+    elif p < alpha:
+        stars = "*"
+    return f"{p:.4f}{(' ' + stars) if stars else ''}"
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Compute bootstrap CIs and paired randomization tests from stored metrics",
+    )
+    parser.add_argument(
+        "--systems",
+        nargs="+",
+        required=True,
+        help="System specifiers of the form name=/path/to/metrics.json",
+    )
+    parser.add_argument(
+        "--baseline",
+        required=True,
+        help="Name of the baseline system (must match one of the --systems names)",
+    )
+    parser.add_argument(
+        "--split",
+        default="val",
+        help="Split to evaluate (e.g., train, val, test)",
+    )
+    parser.add_argument(
+        "--head",
+        choices=["vaccine", "disease"],
+        default="vaccine",
+        help="Ranking head to evaluate",
+    )
+    parser.add_argument(
+        "--metrics",
+        nargs="*",
+        help="Specific metrics to evaluate (default: intersection across systems)",
+    )
+    parser.add_argument(
+        "--bootstrap",
+        type=int,
+        default=1000,
+        help="Number of bootstrap samples for confidence intervals",
+    )
+    parser.add_argument(
+        "--permutations",
+        type=int,
+        default=100_000,
+        help="Iterations for the paired randomization test",
+    )
+    parser.add_argument(
+        "--alpha",
+        type=float,
+        default=0.05,
+        help="Significance level for CIs and star annotations",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=13,
+        help="Base random seed for bootstrap/permutation procedures",
+    )
+    return parser
+
+
+def main() -> None:
+    parser = build_arg_parser()
+    args = parser.parse_args()
+
+    specs = parse_system_specs(args.systems)
+    system_order = [name for name, _ in specs]
+    if args.baseline not in system_order:
+        raise ValueError("--baseline must match one of the provided system names")
+
+    per_query_data: Dict[str, Dict[str, Dict[str, float]]] = {}
+    macro_data: Dict[str, Mapping[str, float]] = {}
+    for name, path in specs:
+        per_query, macro = load_per_query_metrics(path, head=args.head, split=args.split)
+        per_query_data[name] = per_query
+        macro_data[name] = macro
+
+    baseline_macro = macro_data[args.baseline]
+
+    if args.metrics:
+        metrics_to_use = args.metrics
+    else:
+        available = intersect_metric_names(per_query_data[args.baseline])
+        if not available:
+            raise ValueError("No metrics found in baseline per-query data")
+        metrics_to_use = sorted(available)
+
+    rng_master = np.random.default_rng(args.seed)
+
+    print(
+        f"Split: {args.split} | Head: {args.head} | Baseline: {args.baseline} | Systems: "
+        f"{', '.join(system_order)}"
+    )
+    print()
+
+    for metric in metrics_to_use:
+        ids = common_query_ids(per_query_data, metric)
+        n_queries = len(ids)
+        if n_queries == 0:
+            continue
+
+        metric_arrays: Dict[str, np.ndarray] = {}
+        for name in system_order:
+            per_query = per_query_data[name]
+            metric_arrays[name] = np.array(
+                [per_query[qid][metric] for qid in ids],
+                dtype=float,
+            )
+
+        baseline_values = metric_arrays[args.baseline]
+        baseline_mean = float(baseline_values.mean())
+        baseline_ci_lo, baseline_ci_hi = percentile_bootstrap_ci(
+            baseline_values,
+            iterations=args.bootstrap,
+            alpha=args.alpha,
+            rng=np.random.default_rng(rng_master.integers(0, 2**32)),
+        )
+
+        print(f"Metric: {metric} (n={n_queries})")
+        print(f"{'System':<20}{'Mean':>12}{'95% CI':>20}{('Δ vs ' + args.baseline):>18}{'p-value':>12}")
+
+        for name in system_order:
+            values = metric_arrays[name]
+            mean = float(values.mean())
+            ci_lo, ci_hi = percentile_bootstrap_ci(
+                values,
+                iterations=args.bootstrap,
+                alpha=args.alpha,
+                rng=np.random.default_rng(rng_master.integers(0, 2**32)),
+            )
+            ci_str = format_ci(ci_lo, ci_hi)
+            if name == args.baseline:
+                diff_str = f"{0.0:+.4f}"
+                p_str = "-"
+            else:
+                diff, p_value = paired_randomization_test(
+                    values,
+                    baseline_values,
+                    iterations=args.permutations,
+                    rng=np.random.default_rng(rng_master.integers(0, 2**32)),
+                )
+                diff_str = f"{diff:+.4f}"
+                p_str = format_p_value(p_value, args.alpha)
+
+            print(f"{name:<20}{mean:>12.4f}{ci_str:>20}{diff_str:>18}{p_str:>12}")
+
+        if metric in baseline_macro:
+            macro_mean = float(baseline_macro[metric])
+            if abs(macro_mean - baseline_mean) > 1e-6:
+                print(
+                    f"  [warn] Stored macro mean for baseline ({macro_mean:.4f}) "
+                    f"differs from per-query mean ({baseline_mean:.4f})."
+                )
+
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/export_case_study.py
+++ b/src/export_case_study.py
@@ -7,12 +7,13 @@ import json
 import math
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Mapping, MutableMapping, Optional, Sequence, Tuple
+from typing import Dict, List, Mapping, MutableMapping, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import pandas as pd
 import torch
-from torch import Tensor
+import torch.nn.functional as F
+from torch import Tensor, nn
 
 from train_disease_ranker import (  # type: ignore
     DEFAULT_TEXT_ENCODER_MAX_LENGTHS,
@@ -42,6 +43,50 @@ class ReliabilityBin:
     confidence: float
     precision: float
     count: int
+
+
+class LegacyListNetRanker(nn.Module):
+    """Dot-product ranking head used by the original ``train_ranker.py`` script."""
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    @staticmethod
+    def _dot_product(query: Tensor, candidates: Tensor) -> Tensor:
+        if query.dim() == 2 and candidates.dim() == 3:
+            expanded = query.unsqueeze(1).expand_as(candidates)
+            return (expanded * candidates).sum(dim=-1)
+        return (query * candidates).sum(dim=-1)
+
+    def score_vax(self, h_vax: Tensor, h_adj: Tensor) -> Tensor:
+        return self._dot_product(h_vax, h_adj)
+
+    def score_dis(
+        self, h_dis: Tensor, h_adj: Tensor, mech_vec: Optional[Tensor] = None
+    ) -> Tensor:
+        del mech_vec  # Legacy head ignores mechanism cues entirely.
+        return self._dot_product(h_dis, h_adj)
+
+    def forward(
+        self,
+        embeddings: Mapping[str, Tensor],
+        vaccine_indices: Tensor,
+        candidate_indices: Tensor,
+        relevance: Tensor,
+    ) -> Tuple[Tensor, Tensor]:
+        vaccine_repr = embeddings["vaccine"][vaccine_indices]
+        adjuvant_repr = embeddings["adjuvant"][candidate_indices]
+        scores = self.score_vax(vaccine_repr, adjuvant_repr)
+
+        positive_mask = (relevance > 0).float()
+        positive_mass = positive_mask.sum(dim=1, keepdim=True).clamp_min(1e-9)
+        target_distribution = positive_mask / positive_mass
+        log_probs = F.log_softmax(scores, dim=1)
+        loss = -(target_distribution * log_probs).sum(dim=1).mean()
+        return loss, scores
+
+
+RankerModule = Union[DualRanker, LegacyListNetRanker]
 
 
 def parse_args() -> argparse.Namespace:
@@ -175,11 +220,43 @@ def _prepare_text_encoder(ckpt_args: Mapping[str, object], device: torch.device)
 
 def _load_checkpoint(path: Path) -> MutableMapping[str, object]:
     checkpoint = torch.load(path, map_location="cpu")
-    required_keys = {"state_dict", "ranking_head_state_dict", "args"}
+
+    # Backwards compatibility for checkpoints produced before DualRanker support.
+    # Older files bundled every parameter under ``state_dict`` (including the
+    # ranking head) or stored the model weights under ``model_state_dict``.
+    if "state_dict" not in checkpoint and "model_state_dict" in checkpoint:
+        checkpoint["state_dict"] = checkpoint.pop("model_state_dict")
+
+    if "ranking_head_state_dict" not in checkpoint:
+        state = checkpoint.get("state_dict")
+        if isinstance(state, Mapping):
+            prefix = "ranking_head."
+            ranking_keys = [key for key in state if key.startswith(prefix)]
+            if ranking_keys:
+                checkpoint["ranking_head_state_dict"] = {
+                    key[len(prefix) :]: state[key]
+                    for key in ranking_keys
+                }
+                for key in ranking_keys:
+                    del state[key]
+
+    legacy_head = "ranking_head_state_dict" not in checkpoint
+    checkpoint["_legacy_listnet_head"] = legacy_head
+
+    required_keys = {"state_dict", "args"}
     missing = required_keys - checkpoint.keys()
     if missing:
         missing_str = ", ".join(sorted(missing))
-        raise KeyError(f"Checkpoint at {path} is missing required keys: {missing_str}")
+        raise KeyError(
+            "Checkpoint at "
+            f"{path} is missing required keys: {missing_str}. "
+            "The file was likely produced by an outdated training script."
+        )
+    if not legacy_head and "ranking_head_state_dict" not in checkpoint:
+        raise KeyError(
+            "Checkpoint at "
+            f"{path} is missing 'ranking_head_state_dict' despite recovery attempts."
+        )
     return checkpoint
 
 
@@ -188,7 +265,7 @@ def _build_model(
     ckpt_args: Mapping[str, object],
     checkpoint: Mapping[str, object],
     device: torch.device,
-) -> Tuple[PyGHeteroEncoder, DualRanker, Optional[Tensor]]:
+) -> Tuple[PyGHeteroEncoder, RankerModule, Optional[Tensor]]:
     node_feat_dims = {nt: graph[nt].x.size(1) for nt in graph.node_types}
     model = PyGHeteroEncoder(
         node_feat_dims,
@@ -208,12 +285,20 @@ def _build_model(
     mech_dim = int(structured.size(1)) if isinstance(structured, Tensor) else 0
     use_mech = bool(ckpt_args.get("enable_disease_mechanism_cues", False)) and mech_dim > 0
     mech_in_dim = mech_dim if use_mech else None
-    ranking_head = DualRanker(
-        int(ckpt_args.get("hidden_dim", 128)),
-        mech_in_dim,
-        float(ckpt_args.get("gamma_mech", 0.3)),
-    )
-    ranking_head.load_state_dict(checkpoint["ranking_head_state_dict"])
+    legacy_head = bool(checkpoint.get("_legacy_listnet_head", False))
+    if legacy_head:
+        print(
+            "Warning: checkpoint lacks a dedicated ranking head; using legacy "
+            "dot-product scores (disease ranking quality may degrade)."
+        )
+        ranking_head: RankerModule = LegacyListNetRanker()
+    else:
+        ranking_head = DualRanker(
+            int(ckpt_args.get("hidden_dim", 128)),
+            mech_in_dim,
+            float(ckpt_args.get("gamma_mech", 0.3)),
+        )
+        ranking_head.load_state_dict(checkpoint["ranking_head_state_dict"])
     ranking_head = ranking_head.to(device)
     ranking_head.eval()
 
@@ -228,7 +313,7 @@ def _score_disease(
     disease_idx: int,
     candidate_ids: Sequence[int],
     model: PyGHeteroEncoder,
-    ranking_head: DualRanker,
+    ranking_head: RankerModule,
     graph: "HeteroData",
     adjuvant_mechanism: Optional[Tensor],
     device: torch.device,

--- a/src/export_case_study.py
+++ b/src/export_case_study.py
@@ -158,7 +158,16 @@ def parse_args() -> argparse.Namespace:
         "--reliability-bins",
         type=int,
         default=10,
-        help="Number of equal-width bins for the reliability diagram.",
+        help="Number of bins for the reliability diagram.",
+    )
+    parser.add_argument(
+        "--reliability-binning",
+        choices=("equal_width", "quantile"),
+        default="equal_width",
+        help=(
+            "Binning strategy for reliability diagram: equal-width score intervals or "
+            "quantile bins with comparable sample counts."
+        ),
     )
     parser.add_argument(
         "--score-normalization",
@@ -400,9 +409,10 @@ def _compute_reliability(
     positives: Sequence[int],
     bins: int,
     normalisation: str,
-) -> Tuple[List[ReliabilityBin], float]:
+    binning: str,
+) -> Tuple[List[ReliabilityBin], float, str]:
     if bins <= 0 or scores.size == 0:
-        return [], 0.0
+        return [], 0.0, "equal_width"
 
     if normalisation == "sigmoid":
         norm_scores = 1.0 / (1.0 + np.exp(-scores))
@@ -418,7 +428,18 @@ def _compute_reliability(
     counts = np.zeros(bins, dtype=int)
     confs = np.zeros(bins, dtype=float)
     precs = np.zeros(bins, dtype=float)
-    edges = np.linspace(0.0, 1.0, bins + 1)
+    applied_mode = "equal_width" if binning != "quantile" else "quantile"
+    if binning == "quantile" and scores.size >= 2 and bins > 1:
+        quantiles = np.linspace(0.0, 1.0, bins + 1)
+        edges = np.quantile(norm_scores, quantiles)
+        edges[0] = float(norm_scores.min())
+        edges[-1] = float(norm_scores.max())
+        if np.any(np.diff(edges) <= 1e-8):
+            edges = np.linspace(0.0, 1.0, bins + 1)
+            applied_mode = "equal_width"
+    else:
+        edges = np.linspace(0.0, 1.0, bins + 1)
+        applied_mode = "equal_width"
     bin_indices = np.digitize(norm_scores, edges, right=False) - 1
     bin_indices = np.clip(bin_indices, 0, bins - 1)
 
@@ -452,7 +473,7 @@ def _compute_reliability(
             )
         )
         ece += (count / total) * abs(precision - confidence)
-    return reliability, float(ece)
+    return reliability, float(ece), applied_mode
 
 
 def _compute_run_metrics(
@@ -464,6 +485,10 @@ def _compute_run_metrics(
     curve_k: int,
     reliability_bins: int,
     normalisation: str,
+    reliability_binning: str,
+    adjuvant_mapping: Mapping[int, str],
+    display_lookup: Mapping[str, str],
+    class_lookup: Mapping[str, str],
 ) -> Dict[str, object]:
     ranked_indices = [int(candidate_ids[i]) for i in run.order]
     metrics: Dict[str, object] = {
@@ -472,7 +497,13 @@ def _compute_run_metrics(
         "num_positives": len(positives),
     }
 
+    score_lookup = {
+        int(candidate_ids[i]): float(run.scores[i]) for i in range(len(candidate_ids))
+    }
+    positives_set = set(positives)
+
     per_k: Dict[str, Dict[str, float]] = {}
+    random_multipliers: Dict[str, Optional[float]] = {}
     for k in topk:
         ranked_slice = ranked_indices[:k]
         per_k[str(k)] = {
@@ -480,14 +511,18 @@ def _compute_run_metrics(
             "recall": _recall_at_k(ranked_slice, positives, k),
             "ndcg": _ndcg_at_k(ranked_slice, gains, positives, k),
         }
+        baseline = k / len(candidate_ids) if len(candidate_ids) > 0 else 0.0
+        if baseline > 0:
+            random_multipliers[str(k)] = per_k[str(k)]["recall"] / baseline
+        else:
+            random_multipliers[str(k)] = None
     metrics["topk"] = per_k
+    metrics["random_recall_multiplier"] = random_multipliers
 
     curve_limit = min(curve_k, len(candidate_ids))
-    dcg_curve = []
-    idcg_curve = []
+    dcg_curve: List[float] = []
+    idcg_curve: List[float] = []
     sorted_gains = sorted(gains.values(), reverse=True)
-    if not sorted_gains:
-        sorted_gains = []
     cumulative_dcg = 0.0
     for idx, candidate in enumerate(ranked_indices[:curve_limit], start=1):
         cumulative_dcg += float(gains.get(candidate, 0.0)) / math.log2(idx + 1)
@@ -499,29 +534,62 @@ def _compute_run_metrics(
         idcg_curve.append(cumulative_idcg)
     metrics["dcg_curve"] = dcg_curve
     metrics["idcg_curve"] = idcg_curve
-    ndcg_at_curve = _ndcg_value(cumulative_dcg, cumulative_idcg)
-    metrics["ndcg@curve_k"] = ndcg_at_curve
+    metrics["ndcg@curve_k"] = _ndcg_value(cumulative_dcg, cumulative_idcg)
+    metrics["ndcg_curve_k"] = [
+        _ndcg_value(dcg_curve[i], idcg_curve[i]) if idcg_curve[i] > 0 else 0.0
+        for i in range(len(dcg_curve))
+    ]
 
-    reliability, ece = _compute_reliability(
+    reliability, ece, applied_binning = _compute_reliability(
         run.scores,
         candidate_ids,
         positives,
         reliability_bins,
         normalisation,
+        reliability_binning,
     )
     metrics["ece"] = ece
-    metrics["reliability_bins"] = [
-        {
-            "lower": bin.lower,
-            "upper": bin.upper,
-            "confidence": bin.confidence,
-            "precision": bin.precision,
-            "count": bin.count,
-        }
-        for bin in reliability
-    ]
-    return metrics
+    metrics["reliability"] = {
+        "mode": applied_binning,
+        "bins": [
+            {
+                "lower": bin.lower,
+                "upper": bin.upper,
+                "confidence": bin.confidence,
+                "precision": bin.precision,
+                "count": bin.count,
+            }
+            for bin in reliability
+        ],
+    }
+    metrics["reliability_bins"] = metrics["reliability"]["bins"]
 
+    first_hit_rank: Optional[int] = None
+    if positives_set:
+        ranks = [run.rank_map.get(pos) for pos in positives_set if pos in run.rank_map]
+        if ranks:
+            first_hit_rank = min(ranks)
+    metrics["first_hit_rank"] = first_hit_rank
+    metrics["mrr"] = (1.0 / first_hit_rank) if first_hit_rank is not None else 0.0
+
+    top_list_limit = min(10, len(ranked_indices))
+    topk_list: List[Dict[str, object]] = []
+    for candidate in ranked_indices[:top_list_limit]:
+        adjuvant_id = adjuvant_mapping.get(candidate, str(candidate))
+        adjuvant_str = str(adjuvant_id)
+        topk_list.append(
+            {
+                "adjuvant_id": adjuvant_str,
+                "adjuvant_label": display_lookup.get(adjuvant_str, adjuvant_str),
+                "score": score_lookup.get(candidate),
+                "relevance_binary": int(candidate in positives_set),
+                "relevance_gain": float(gains.get(candidate, 0.0)),
+                "adjuvant_class": class_lookup.get(adjuvant_str, "unknown"),
+            }
+        )
+    metrics["topk_list"] = topk_list
+
+    return metrics
 
 def _ndcg_value(dcg: float, idcg: float) -> float:
     if idcg <= 0.0:
@@ -734,6 +802,7 @@ def main() -> None:
         "num_candidates": len(candidate_list),
         "num_positives": len(positive_indices),
         "runs": {},
+        "reliability_binning": args.reliability_binning,
     }
     for run in runs:
         metrics_summary["runs"][run.label] = _compute_run_metrics(
@@ -745,6 +814,10 @@ def main() -> None:
             int(args.curve_topk),
             int(args.reliability_bins),
             args.score_normalization,
+            args.reliability_binning,
+            adjuvant_mapping,
+            display_lookup,
+            class_lookup,
         )
 
     if comparison_data is not None:

--- a/src/export_case_study.py
+++ b/src/export_case_study.py
@@ -1,0 +1,655 @@
+"""Export disease→adjuvant ranking data for case study figures."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Mapping, MutableMapping, Optional, Sequence, Tuple
+
+import numpy as np
+import pandas as pd
+import torch
+from torch import Tensor
+
+from train_disease_ranker import (  # type: ignore
+    DEFAULT_TEXT_ENCODER_MAX_LENGTHS,
+    DualRanker,
+    PyGHeteroEncoder,
+    attach_adjuvant_classes,
+    build_graph,
+)
+
+
+@dataclass
+class RunOutputs:
+    """Container for per-run scores and rankings."""
+
+    label: str
+    scores: np.ndarray
+    order: np.ndarray
+    rank_map: Dict[int, int]
+
+
+@dataclass
+class ReliabilityBin:
+    """Reliability diagram bin statistics."""
+
+    lower: float
+    upper: float
+    confidence: float
+    precision: float
+    count: int
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Export disease→adjuvant ranking details for figure generation. "
+            "The script recreates the heterogeneous graph, loads the trained "
+            "encoder + ranking head, and writes a CSV with per-candidate scores "
+            "alongside a JSON summary containing Top-K metrics, DCG curves, and "
+            "reliability statistics."
+        )
+    )
+    parser.add_argument(
+        "--checkpoint",
+        type=Path,
+        required=True,
+        help="Path to the trained checkpoint saved by train_disease_ranker.py",
+    )
+    parser.add_argument(
+        "--comparison-checkpoint",
+        type=Path,
+        default=None,
+        help="Optional checkpoint for a baseline run (enables rank-swap analysis).",
+    )
+    parser.add_argument(
+        "--disease-key",
+        type=str,
+        required=True,
+        help="Disease key (matches the 'disease_key' column produced during training).",
+    )
+    parser.add_argument(
+        "--output-csv",
+        type=Path,
+        required=True,
+        help="Destination CSV containing per-adjuvant scores, ranks, and metadata.",
+    )
+    parser.add_argument(
+        "--summary-json",
+        type=Path,
+        default=None,
+        help="Optional path for metrics summary JSON (defaults to output-csv with .json).",
+    )
+    parser.add_argument(
+        "--data-path",
+        type=Path,
+        default=None,
+        help="Processed training CSV (defaults to the path stored in the checkpoint).",
+    )
+    parser.add_argument(
+        "--device",
+        type=str,
+        default="cpu",
+        help="Torch device for inference (default: cpu).",
+    )
+    parser.add_argument(
+        "--topk",
+        type=int,
+        nargs="*",
+        default=(5, 10),
+        help="Top-k cut-offs for reporting precision/recall/NDCG metrics.",
+    )
+    parser.add_argument(
+        "--curve-topk",
+        type=int,
+        default=10,
+        help="Length of the DCG/IDCG curve (Panel B).",
+    )
+    parser.add_argument(
+        "--reliability-bins",
+        type=int,
+        default=10,
+        help="Number of equal-width bins for the reliability diagram.",
+    )
+    parser.add_argument(
+        "--score-normalization",
+        choices=["minmax", "sigmoid"],
+        default="minmax",
+        help="Normalisation applied before calibration (Panel C).",
+    )
+    parser.add_argument(
+        "--primary-label",
+        type=str,
+        default="target",
+        help="Label for the primary checkpoint (used in JSON + column names).",
+    )
+    parser.add_argument(
+        "--comparison-label",
+        type=str,
+        default="baseline",
+        help="Label for the optional comparison checkpoint.",
+    )
+    parser.add_argument(
+        "--disease-stage-csv",
+        type=Path,
+        default=Path("data/processed/disease_adjuvant_pairs.csv"),
+        help="Optional disease-adjuvant summary CSV (used to attach stage metadata if present).",
+    )
+    return parser.parse_args()
+
+
+def _invert(mapping: Mapping[object, int]) -> Dict[int, object]:
+    return {idx: key for key, idx in mapping.items()}
+
+
+def _prepare_text_encoder(ckpt_args: Mapping[str, object], device: torch.device):
+    checkpoint = ckpt_args.get("text_encoder_checkpoint")
+    if not checkpoint:
+        return None, None
+    from transformers import AutoModel, AutoTokenizer  # type: ignore
+
+    tokenizer = AutoTokenizer.from_pretrained(str(checkpoint))
+    model = AutoModel.from_pretrained(str(checkpoint))
+    model.to(device)
+    model.eval()
+
+    max_lengths = dict(DEFAULT_TEXT_ENCODER_MAX_LENGTHS)
+    override = ckpt_args.get("text_encoder_max_length")
+    if override is not None:
+        for key in max_lengths:
+            max_lengths[key] = int(override)
+    config = {
+        "pooling": ckpt_args.get("text_encoder_pooling", "mean"),
+        "batch_size": int(ckpt_args.get("text_encoder_batch_size", 128)),
+        "max_lengths": max_lengths,
+        "default_max_length": int(override or 64),
+        "device": device,
+        "normalize": not bool(ckpt_args.get("no_text_encoder_normalize", False)),
+    }
+    return (tokenizer, model), config
+
+
+def _load_checkpoint(path: Path) -> MutableMapping[str, object]:
+    checkpoint = torch.load(path, map_location="cpu")
+    required_keys = {"state_dict", "ranking_head_state_dict", "args"}
+    missing = required_keys - checkpoint.keys()
+    if missing:
+        missing_str = ", ".join(sorted(missing))
+        raise KeyError(f"Checkpoint at {path} is missing required keys: {missing_str}")
+    return checkpoint
+
+
+def _build_model(
+    graph: "HeteroData",
+    ckpt_args: Mapping[str, object],
+    checkpoint: Mapping[str, object],
+    device: torch.device,
+) -> Tuple[PyGHeteroEncoder, DualRanker, Optional[Tensor]]:
+    node_feat_dims = {nt: graph[nt].x.size(1) for nt in graph.node_types}
+    model = PyGHeteroEncoder(
+        node_feat_dims,
+        graph.metadata(),
+        int(ckpt_args.get("hidden_dim", 128)),
+        int(ckpt_args.get("layers", 2)),
+        float(ckpt_args.get("dropout", 0.3)),
+        int(ckpt_args.get("appnp_steps", 10)),
+        float(ckpt_args.get("appnp_alpha", 0.1)),
+        float(ckpt_args.get("appnp_dropout", 0.0)),
+    )
+    model.load_state_dict(checkpoint["state_dict"])
+    model = model.to(device)
+    model.eval()
+
+    structured = getattr(graph["adjuvant"], "structured", None)
+    mech_dim = int(structured.size(1)) if isinstance(structured, Tensor) else 0
+    use_mech = bool(ckpt_args.get("enable_disease_mechanism_cues", False)) and mech_dim > 0
+    mech_in_dim = mech_dim if use_mech else None
+    ranking_head = DualRanker(
+        int(ckpt_args.get("hidden_dim", 128)),
+        mech_in_dim,
+        float(ckpt_args.get("gamma_mech", 0.3)),
+    )
+    ranking_head.load_state_dict(checkpoint["ranking_head_state_dict"])
+    ranking_head = ranking_head.to(device)
+    ranking_head.eval()
+
+    if use_mech and isinstance(structured, Tensor):
+        adjuvant_mechanism = structured.to(device)
+    else:
+        adjuvant_mechanism = None
+    return model, ranking_head, adjuvant_mechanism
+
+
+def _score_disease(
+    disease_idx: int,
+    candidate_ids: Sequence[int],
+    model: PyGHeteroEncoder,
+    ranking_head: DualRanker,
+    graph: "HeteroData",
+    adjuvant_mechanism: Optional[Tensor],
+    device: torch.device,
+) -> np.ndarray:
+    graph_device = graph.to(device)
+    with torch.no_grad():
+        embeddings = model(graph_device)
+        disease_vec = embeddings["disease"][disease_idx].unsqueeze(0)
+        candidates = torch.tensor(candidate_ids, dtype=torch.long, device=device)
+        adjuvant_vec = embeddings["adjuvant"][candidates].unsqueeze(0)
+        mech = None
+        if adjuvant_mechanism is not None:
+            mech = adjuvant_mechanism[candidates].unsqueeze(0)
+        scores = ranking_head.score_dis(disease_vec, adjuvant_vec, mech)
+    return scores.squeeze(0).cpu().numpy()
+
+
+def _order_from_scores(
+    scores: np.ndarray, candidate_ids: Sequence[int]
+) -> Tuple[np.ndarray, Dict[int, int]]:
+    order = np.argsort(-scores)
+    rank_map = {
+        int(candidate_ids[idx]): int(rank) for rank, idx in enumerate(order, start=1)
+    }
+    return order, rank_map
+
+
+def _precision_at_k(ranked: Sequence[int], positives: Sequence[int], k: int) -> float:
+    if k <= 0:
+        return 0.0
+    top = ranked[:k]
+    hits = sum(1 for item in top if item in positives)
+    return hits / k
+
+
+def _recall_at_k(ranked: Sequence[int], positives: Sequence[int], k: int) -> float:
+    if not positives:
+        return 0.0
+    top = ranked[:k]
+    hits = sum(1 for item in top if item in positives)
+    return hits / len(positives)
+
+
+def _dcg_at_k(ranked: Sequence[int], gains: Mapping[int, float], k: int) -> float:
+    total = 0.0
+    for idx, item in enumerate(ranked[:k], start=1):
+        gain = float(gains.get(item, 0.0))
+        if gain <= 0:
+            continue
+        total += gain / math.log2(idx + 1)
+    return total
+
+
+def _compute_reliability(
+    scores: np.ndarray,
+    candidate_ids: Sequence[int],
+    positives: Sequence[int],
+    bins: int,
+    normalisation: str,
+) -> Tuple[List[ReliabilityBin], float]:
+    if bins <= 0 or scores.size == 0:
+        return [], 0.0
+
+    if normalisation == "sigmoid":
+        norm_scores = 1.0 / (1.0 + np.exp(-scores))
+    else:  # minmax
+        min_score = float(scores.min())
+        max_score = float(scores.max())
+        if math.isclose(max_score, min_score):
+            norm_scores = np.full_like(scores, 0.5, dtype=float)
+        else:
+            norm_scores = (scores - min_score) / (max_score - min_score)
+
+    positives_set = set(positives)
+    counts = np.zeros(bins, dtype=int)
+    confs = np.zeros(bins, dtype=float)
+    precs = np.zeros(bins, dtype=float)
+    edges = np.linspace(0.0, 1.0, bins + 1)
+    bin_indices = np.digitize(norm_scores, edges, right=False) - 1
+    bin_indices = np.clip(bin_indices, 0, bins - 1)
+
+    for idx, bin_id in enumerate(bin_indices):
+        counts[bin_id] += 1
+        confs[bin_id] += norm_scores[idx]
+        candidate = int(candidate_ids[idx])
+        precs[bin_id] += 1.0 if candidate in positives_set else 0.0
+
+    reliability: List[ReliabilityBin] = []
+    total = scores.size
+    ece = 0.0
+    for bin_id in range(bins):
+        count = int(counts[bin_id])
+        lower = float(edges[bin_id])
+        upper = float(edges[bin_id + 1])
+        if count == 0:
+            reliability.append(
+                ReliabilityBin(lower=lower, upper=upper, confidence=0.0, precision=0.0, count=0)
+            )
+            continue
+        confidence = confs[bin_id] / count
+        precision = precs[bin_id] / count
+        reliability.append(
+            ReliabilityBin(
+                lower=lower,
+                upper=upper,
+                confidence=float(confidence),
+                precision=float(precision),
+                count=count,
+            )
+        )
+        ece += (count / total) * abs(precision - confidence)
+    return reliability, float(ece)
+
+
+def _compute_run_metrics(
+    run: RunOutputs,
+    candidate_ids: Sequence[int],
+    positives: Sequence[int],
+    gains: Mapping[int, float],
+    topk: Sequence[int],
+    curve_k: int,
+    reliability_bins: int,
+    normalisation: str,
+) -> Dict[str, object]:
+    ranked_indices = [int(candidate_ids[i]) for i in run.order]
+    metrics: Dict[str, object] = {
+        "label": run.label,
+        "num_candidates": len(candidate_ids),
+        "num_positives": len(positives),
+    }
+
+    per_k: Dict[str, Dict[str, float]] = {}
+    for k in topk:
+        ranked_slice = ranked_indices[:k]
+        per_k[str(k)] = {
+            "precision": _precision_at_k(ranked_slice, positives, k),
+            "recall": _recall_at_k(ranked_slice, positives, k),
+            "ndcg": _ndcg_at_k(ranked_slice, gains, positives, k),
+        }
+    metrics["topk"] = per_k
+
+    curve_limit = min(curve_k, len(candidate_ids))
+    dcg_curve = []
+    idcg_curve = []
+    sorted_gains = sorted(gains.values(), reverse=True)
+    if not sorted_gains:
+        sorted_gains = []
+    cumulative_dcg = 0.0
+    for idx, candidate in enumerate(ranked_indices[:curve_limit], start=1):
+        cumulative_dcg += float(gains.get(candidate, 0.0)) / math.log2(idx + 1)
+        dcg_curve.append(cumulative_dcg)
+    cumulative_idcg = 0.0
+    for idx in range(1, curve_limit + 1):
+        gain = float(sorted_gains[idx - 1]) if idx - 1 < len(sorted_gains) else 0.0
+        cumulative_idcg += gain / math.log2(idx + 1)
+        idcg_curve.append(cumulative_idcg)
+    metrics["dcg_curve"] = dcg_curve
+    metrics["idcg_curve"] = idcg_curve
+    ndcg_at_curve = _ndcg_value(cumulative_dcg, cumulative_idcg)
+    metrics["ndcg@curve_k"] = ndcg_at_curve
+
+    reliability, ece = _compute_reliability(
+        run.scores,
+        candidate_ids,
+        positives,
+        reliability_bins,
+        normalisation,
+    )
+    metrics["ece"] = ece
+    metrics["reliability_bins"] = [
+        {
+            "lower": bin.lower,
+            "upper": bin.upper,
+            "confidence": bin.confidence,
+            "precision": bin.precision,
+            "count": bin.count,
+        }
+        for bin in reliability
+    ]
+    return metrics
+
+
+def _ndcg_value(dcg: float, idcg: float) -> float:
+    if idcg <= 0.0:
+        return 0.0
+    return dcg / idcg
+
+
+def _ndcg_at_k(
+    ranked: Sequence[int],
+    gains: Mapping[int, float],
+    positives: Sequence[int],
+    k: int,
+) -> float:
+    if k <= 0:
+        return 0.0
+    dcg = _dcg_at_k(ranked, gains, k)
+    ideal_gains = sorted((gains.get(idx, 1.0) for idx in positives), reverse=True)
+    ideal = 0.0
+    for idx in range(1, min(k, len(ideal_gains)) + 1):
+        ideal += ideal_gains[idx - 1] / math.log2(idx + 1)
+    return _ndcg_value(dcg, ideal)
+
+
+def _collect_display_labels(df: pd.DataFrame) -> Dict[str, str]:
+    labels: Dict[str, str] = {}
+    columns = [
+        "adjuvant_display_name",
+        "vo_preferred_label",
+        "adjuvant_name",
+    ]
+    for adjuvant_id, group in df.groupby("adjuvant_vo_id"):
+        label = None
+        for column in columns:
+            if column in group and column in df.columns:
+                series = group[column].dropna()
+                if not series.empty:
+                    value = str(series.iloc[0]).strip()
+                    if value:
+                        label = value
+                        break
+        labels[str(adjuvant_id)] = label or str(adjuvant_id)
+    return labels
+
+
+def main() -> None:
+    args = parse_args()
+    summary_path = args.summary_json or args.output_csv.with_suffix(".json")
+    device = torch.device(args.device)
+    topk_values = sorted({int(k) for k in args.topk if int(k) > 0})
+    if not topk_values:
+        raise ValueError("At least one positive --topk value is required")
+
+    checkpoint = _load_checkpoint(args.checkpoint)
+    ckpt_args: Mapping[str, object] = checkpoint["args"]
+
+    data_path = args.data_path or Path(ckpt_args.get("data_path", ""))
+    if not data_path:
+        raise FileNotFoundError(
+            "Data path not provided and checkpoint metadata is missing 'data_path'."
+        )
+    if not Path(data_path).exists():
+        raise FileNotFoundError(f"Training data CSV not found at {data_path}")
+
+    df = pd.read_csv(data_path)
+    df = attach_adjuvant_classes(df)
+    text_encoder, encoder_config = _prepare_text_encoder(ckpt_args, device)
+    graph, mappings, _, _, candidate_ids, disease_positives_lookup, disease_edge_weights = build_graph(
+        df,
+        int(ckpt_args.get("feature_dim", 256)),
+        text_encoder=text_encoder,
+        text_encoder_config=encoder_config,
+        enable_disease_structured=bool(ckpt_args.get("enable_disease_mechanism_cues", False)),
+    )
+
+    if text_encoder is not None:
+        tokenizer, model = text_encoder
+        model.to("cpu")
+        del tokenizer
+        del model
+
+    disease_mapping = mappings["disease"]
+    disease_key = args.disease_key
+    disease_idx = disease_mapping.get(disease_key)
+    if disease_idx is None:
+        lowered = {key.lower(): value for key, value in disease_mapping.items()}
+        disease_idx = lowered.get(disease_key.lower())
+    if disease_idx is None:
+        available = ", ".join(sorted(disease_mapping.keys())[:20])
+        raise KeyError(
+            f"Disease key '{args.disease_key}' not found. Example keys: {available}..."
+        )
+
+    candidate_list = list(candidate_ids)
+    adjuvant_mapping = _invert(mappings["adjuvant"])
+    positive_indices = disease_positives_lookup.get(disease_idx, [])
+    gains: Dict[int, float] = {
+        int(adj_idx): float(disease_edge_weights.get((disease_idx, adj_idx), 1.0))
+        for adj_idx in positive_indices
+    }
+
+    model, ranking_head, adjuvant_mechanism = _build_model(
+        graph,
+        ckpt_args,
+        checkpoint,
+        device,
+    )
+    primary_scores = _score_disease(
+        disease_idx,
+        candidate_list,
+        model,
+        ranking_head,
+        graph,
+        adjuvant_mechanism,
+        device,
+    )
+    primary_order, primary_ranks = _order_from_scores(primary_scores, candidate_list)
+    primary_score_map = {
+        candidate_list[i]: float(primary_scores[i]) for i in range(len(candidate_list))
+    }
+    runs = [
+        RunOutputs(
+            label=args.primary_label,
+            scores=primary_scores,
+            order=primary_order,
+            rank_map=primary_ranks,
+        )
+    ]
+
+    comparison_data: Optional[RunOutputs] = None
+    comp_score_map: Dict[int, float] = {}
+    if args.comparison_checkpoint is not None:
+        comparison_ckpt = _load_checkpoint(args.comparison_checkpoint)
+        comparison_args: Mapping[str, object] = comparison_ckpt["args"]
+        if comparison_args.get("data_path") != ckpt_args.get("data_path"):
+            print("Warning: comparison checkpoint was trained on a different data path.")
+        comp_model, comp_head, comp_mech = _build_model(
+            graph,
+            comparison_args,
+            comparison_ckpt,
+            device,
+        )
+        comp_scores = _score_disease(
+            disease_idx,
+            candidate_list,
+            comp_model,
+            comp_head,
+            graph,
+            comp_mech,
+            device,
+        )
+        comp_order, comp_ranks = _order_from_scores(comp_scores, candidate_list)
+        comp_score_map = {
+            candidate_list[i]: float(comp_scores[i]) for i in range(len(candidate_list))
+        }
+        comparison_data = RunOutputs(
+            label=args.comparison_label,
+            scores=comp_scores,
+            order=comp_order,
+            rank_map=comp_ranks,
+        )
+        runs.append(comparison_data)
+
+    class_lookup = (
+        df.groupby("adjuvant_vo_id")["adjuvant_class"].first().to_dict()
+        if "adjuvant_class" in df.columns
+        else {}
+    )
+    display_lookup = _collect_display_labels(df)
+
+    stage_lookup: Dict[Tuple[str, str], str] = {}
+    if args.disease_stage_csv and args.disease_stage_csv.exists():
+        stage_df = pd.read_csv(args.disease_stage_csv)
+        if {"disease_key", "adjuvant_vo_id", "stage_mode"}.issubset(stage_df.columns):
+            stage_lookup = {
+                (str(row["disease_key"]), str(row["adjuvant_vo_id"])): str(row["stage_mode"])
+                for _, row in stage_df.iterrows()
+            }
+
+    primary_ranked_indices = [candidate_list[idx] for idx in primary_order]
+    rows: List[Dict[str, object]] = []
+    for candidate_idx in primary_ranked_indices:
+        adjuvant_id = str(adjuvant_mapping[candidate_idx])
+        row: Dict[str, object] = {
+            "disease_key": disease_key,
+            "adjuvant_vo_id": adjuvant_id,
+            "adjuvant_label": display_lookup.get(adjuvant_id, adjuvant_id),
+            "adjuvant_class": class_lookup.get(adjuvant_id, "unknown"),
+            f"score_{args.primary_label}": primary_score_map[candidate_idx],
+            f"rank_{args.primary_label}": int(primary_ranks[candidate_idx]),
+            "relevance_binary": int(candidate_idx in positive_indices),
+            "relevance_gain": float(gains.get(candidate_idx, 0.0)),
+            "edge_weight": float(disease_edge_weights.get((disease_idx, candidate_idx), 0.0)),
+            "stage_mode": stage_lookup.get((disease_key, adjuvant_id), ""),
+        }
+        if comparison_data is not None:
+            row[f"score_{args.comparison_label}"] = comp_score_map[candidate_idx]
+            row[f"rank_{args.comparison_label}"] = int(
+                comparison_data.rank_map[candidate_idx]
+            )
+        rows.append(row)
+
+    output_df = pd.DataFrame(rows)
+    output_df.sort_values(by=f"rank_{args.primary_label}", inplace=True)
+    args.output_csv.parent.mkdir(parents=True, exist_ok=True)
+    output_df.to_csv(args.output_csv, index=False)
+    print(f"Wrote candidate table to {args.output_csv}")
+
+    metrics_summary = {
+        "disease_key": disease_key,
+        "num_candidates": len(candidate_list),
+        "num_positives": len(positive_indices),
+        "runs": {},
+    }
+    for run in runs:
+        metrics_summary["runs"][run.label] = _compute_run_metrics(
+            run,
+            candidate_list,
+            positive_indices,
+            gains,
+            tuple(topk_values),
+            int(args.curve_topk),
+            int(args.reliability_bins),
+            args.score_normalization,
+        )
+
+    if comparison_data is not None:
+        deltas: Dict[str, float] = {}
+        for k in topk_values:
+            primary_ndcg = metrics_summary["runs"][args.primary_label]["topk"][str(k)]["ndcg"]
+            baseline_ndcg = metrics_summary["runs"][args.comparison_label]["topk"][str(k)][
+                "ndcg"
+            ]
+            deltas[f"ndcg@{k}"] = primary_ndcg - baseline_ndcg
+        metrics_summary["delta_ndcg"] = deltas
+
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    with summary_path.open("w", encoding="utf-8") as handle:
+        json.dump(metrics_summary, handle, indent=2)
+    print(f"Wrote summary metrics to {summary_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/export_case_study.py
+++ b/src/export_case_study.py
@@ -7,7 +7,7 @@ import json
 import math
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Mapping, MutableMapping, Optional, Sequence, Tuple, Union
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -218,6 +218,21 @@ def _prepare_text_encoder(ckpt_args: Mapping[str, object], device: torch.device)
     return (tokenizer, model), config
 
 
+def _looks_like_dual_ranker_checkpoint(args: Mapping[str, object]) -> bool:
+    """Heuristically determine if ``train_disease_ranker.py`` produced the checkpoint."""
+
+    # The dual-ranker script introduces several disease-specific hyperparameters that
+    # never existed in the original ``train_ranker.py`` CLI.  Presence of any of these
+    # keys therefore implies the checkpoint *should* contain a dedicated ranking head.
+    dual_ranker_keys: Iterable[str] = (
+        "lambda_disease",
+        "disease_ndcg_weight",
+        "disease_listnet_weight",
+        "disease_batch_size",
+    )
+    return any(key in args for key in dual_ranker_keys)
+
+
 def _load_checkpoint(path: Path) -> MutableMapping[str, object]:
     checkpoint = torch.load(path, map_location="cpu")
 
@@ -240,9 +255,6 @@ def _load_checkpoint(path: Path) -> MutableMapping[str, object]:
                 for key in ranking_keys:
                     del state[key]
 
-    legacy_head = "ranking_head_state_dict" not in checkpoint
-    checkpoint["_legacy_listnet_head"] = legacy_head
-
     required_keys = {"state_dict", "args"}
     missing = required_keys - checkpoint.keys()
     if missing:
@@ -252,6 +264,21 @@ def _load_checkpoint(path: Path) -> MutableMapping[str, object]:
             f"{path} is missing required keys: {missing_str}. "
             "The file was likely produced by an outdated training script."
         )
+    args = checkpoint.get("args", {})
+    if not isinstance(args, Mapping):
+        args = {}
+
+    legacy_head = "ranking_head_state_dict" not in checkpoint
+    if legacy_head and _looks_like_dual_ranker_checkpoint(args):
+        raise KeyError(
+            "Checkpoint at "
+            f"{path} was produced by train_disease_ranker.py but is missing "
+            "'ranking_head_state_dict'. The run likely failed before saving the "
+            "disease head; please re-train to generate a complete checkpoint."
+        )
+
+    checkpoint["_legacy_listnet_head"] = legacy_head
+
     if not legacy_head and "ranking_head_state_dict" not in checkpoint:
         raise KeyError(
             "Checkpoint at "

--- a/tests/test_case_study_panels.py
+++ b/tests/test_case_study_panels.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+from analysis.draw_case_study_panels import _compute_rank_swaps, create_case_study_panels
+
+
+def _build_sample_summary(tmp_path: Path) -> Path:
+    summary = {
+        "disease_key": "COVID-19",
+        "runs": {
+            "target": {
+                "topk": {
+                    "5": {"precision": 0.2, "recall": 0.2, "ndcg": 0.3},
+                    "10": {"precision": 0.1, "recall": 0.5, "ndcg": 0.4},
+                },
+                "dcg_curve": [1.0, 1.2, 1.2, 1.2, 1.2],
+                "idcg_curve": [1.0, 1.5, 1.7, 1.8, 1.9],
+                "ndcg@curve_k": 0.632,
+                "ndcg_curve_k": [1.0, 0.8, 0.71, 0.66, 0.63],
+                "ece": 0.073,
+                "reliability": {
+                    "mode": "equal_width",
+                    "bins": [
+                        {"lower": 0.0, "upper": 0.33, "confidence": 0.1, "precision": 0.0, "count": 2},
+                        {"lower": 0.33, "upper": 0.66, "confidence": 0.55, "precision": 0.5, "count": 3},
+                        {"lower": 0.66, "upper": 1.0, "confidence": 0.8, "precision": 1.0, "count": 1},
+                    ],
+                },
+                "topk_list": [
+                    {
+                        "adjuvant_id": "Adj-1",
+                        "adjuvant_label": "Adj 1",
+                        "score": 0.91,
+                        "relevance_binary": 1,
+                    },
+                    {
+                        "adjuvant_id": "Adj-2",
+                        "adjuvant_label": "Adj 2",
+                        "score": 0.65,
+                        "relevance_binary": 0,
+                    },
+                    {
+                        "adjuvant_id": "Adj-3",
+                        "adjuvant_label": "Adj 3",
+                        "score": 0.5,
+                        "relevance_binary": 0,
+                    },
+                ],
+            },
+            "baseline": {
+                "topk": {
+                    "5": {"precision": 0.0, "recall": 0.0, "ndcg": 0.1},
+                    "10": {"precision": 0.1, "recall": 0.3, "ndcg": 0.2},
+                },
+                "dcg_curve": [0.5, 0.5, 0.5, 0.5, 0.5],
+                "idcg_curve": [1.0, 1.5, 1.7, 1.8, 1.9],
+                "ndcg@curve_k": 0.26,
+                "ndcg_curve_k": [0.5, 0.33, 0.29, 0.27, 0.26],
+                "ece": 0.15,
+                "reliability": {
+                    "mode": "equal_width",
+                    "bins": [
+                        {"lower": 0.0, "upper": 0.33, "confidence": 0.15, "precision": 0.0, "count": 2},
+                        {"lower": 0.33, "upper": 0.66, "confidence": 0.5, "precision": 0.3, "count": 3},
+                        {"lower": 0.66, "upper": 1.0, "confidence": 0.7, "precision": 0.6, "count": 1},
+                    ],
+                },
+                "topk_list": [],
+            },
+        },
+        "delta_ndcg": {"ndcg@5": 0.2, "ndcg@10": 0.2},
+    }
+    summary_path = tmp_path / "summary.json"
+    with summary_path.open("w", encoding="utf-8") as handle:
+        json.dump(summary, handle)
+    return summary_path
+
+
+def _build_sample_csv(tmp_path: Path) -> Path:
+    df = pd.DataFrame(
+        [
+            {
+                "adjuvant_vo_id": "Adj-1",
+                "adjuvant_label": "Adj 1",
+                "rank_target": 1,
+                "rank_baseline": 4,
+                "relevance_binary": 1,
+            },
+            {
+                "adjuvant_vo_id": "Adj-2",
+                "adjuvant_label": "Adj 2",
+                "rank_target": 2,
+                "rank_baseline": 2,
+                "relevance_binary": 1,
+            },
+            {
+                "adjuvant_vo_id": "Adj-3",
+                "adjuvant_label": "Adj 3",
+                "rank_target": 3,
+                "rank_baseline": 3,
+                "relevance_binary": 0,
+            },
+        ]
+    )
+    csv_path = tmp_path / "candidates.csv"
+    df.to_csv(csv_path, index=False)
+    return csv_path
+
+
+def test_compute_rank_swaps_orders_by_improvement(tmp_path: Path) -> None:
+    csv_path = _build_sample_csv(tmp_path)
+    df = pd.read_csv(csv_path)
+    swaps = _compute_rank_swaps(df, primary_label="target", baseline_label="baseline")
+    assert [entry["label"] for entry in swaps] == ["Adj 1", "Adj 2"]
+    assert swaps[0]["delta"] == 3
+    assert swaps[1]["delta"] == 0
+
+
+def test_create_case_study_panels_writes_image(tmp_path: Path) -> None:
+    summary_path = _build_sample_summary(tmp_path)
+    csv_path = _build_sample_csv(tmp_path)
+    output_path = tmp_path / "figure.png"
+
+    create_case_study_panels(
+        summary_path=summary_path,
+        output_path=output_path,
+        candidates_csv=csv_path,
+        primary_label="target",
+        baseline_label="baseline",
+    )
+
+    assert output_path.exists()
+    assert output_path.stat().st_size > 0

--- a/tests/test_export_case_study_legacy.py
+++ b/tests/test_export_case_study_legacy.py
@@ -96,3 +96,23 @@ def test_legacy_checkpoint_falls_back_to_dot_product(monkeypatch, tmp_path, caps
     assert isinstance(model, DummyEncoder)
     assert model.state_loaded is True
     assert adjuvant_mechanism is None
+
+
+def test_dual_ranker_checkpoint_without_head_errors(tmp_path):
+    """Modern checkpoints should refuse to load if the ranking head is missing."""
+
+    ckpt_path = tmp_path / "broken.pt"
+    dual_args = {
+        "data_path": "dummy.csv",
+        "hidden_dim": 8,
+        "lambda_disease": 0.5,
+        "disease_ndcg_weight": 1.0,
+    }
+    torch.save({"state_dict": {}, "args": dual_args}, ckpt_path)
+
+    with pytest.raises(KeyError) as err:
+        ecs._load_checkpoint(ckpt_path)
+
+    message = str(err.value)
+    assert "train_disease_ranker.py" in message
+    assert "ranking_head_state_dict" in message

--- a/tests/test_export_case_study_legacy.py
+++ b/tests/test_export_case_study_legacy.py
@@ -19,6 +19,8 @@ if str(SRC_DIR) not in sys.path:
 
 import export_case_study as ecs  # noqa: E402
 
+np = ecs.np
+
 
 class DummyGraph:
     """Minimal stand-in for the PyG HeteroData object."""
@@ -116,3 +118,89 @@ def test_dual_ranker_checkpoint_without_head_errors(tmp_path):
     message = str(err.value)
     assert "train_disease_ranker.py" in message
     assert "ranking_head_state_dict" in message
+
+
+def test_compute_reliability_quantile_and_equal_width():
+    scores = np.array([0.0, 1.0, 2.0, 3.0], dtype=float)
+    candidate_ids = [0, 1, 2, 3]
+    positives = [0, 2]
+
+    quantile_bins, quantile_ece, mode = ecs._compute_reliability(
+        scores,
+        candidate_ids,
+        positives,
+        bins=2,
+        normalisation="minmax",
+        binning="quantile",
+    )
+    assert mode == "quantile"
+    assert [bin.count for bin in quantile_bins] == [2, 2]
+    assert pytest.approx(quantile_ece, rel=1e-4) == 1 / 3
+
+    width_bins, width_ece, mode_width = ecs._compute_reliability(
+        scores,
+        candidate_ids,
+        positives,
+        bins=2,
+        normalisation="minmax",
+        binning="equal_width",
+    )
+    assert mode_width == "equal_width"
+    assert [bin.count for bin in width_bins] == [2, 2]
+    assert pytest.approx(width_ece, rel=1e-4) == pytest.approx(quantile_ece)
+
+
+def test_compute_reliability_quantile_fallback():
+    scores = np.array([0.5, 0.5, 0.5], dtype=float)
+    candidate_ids = [0, 1, 2]
+    positives = [1]
+
+    bins, ece, mode = ecs._compute_reliability(
+        scores,
+        candidate_ids,
+        positives,
+        bins=3,
+        normalisation="minmax",
+        binning="quantile",
+    )
+    assert mode == "equal_width"
+    assert sum(bin.count for bin in bins) == len(scores)
+    assert ece == pytest.approx(0.0)
+
+
+def test_compute_run_metrics_enrichments():
+    scores = np.array([0.9, 0.8, 0.2, 0.1], dtype=float)
+    candidate_ids = [0, 1, 2, 3]
+    order = np.array([0, 1, 2, 3], dtype=int)
+    rank_map = {candidate_ids[idx]: idx + 1 for idx in range(len(candidate_ids))}
+    run = ecs.RunOutputs(label="primary", scores=scores, order=order, rank_map=rank_map)
+
+    positives = [0, 2]
+    gains = {0: 1.0, 2: 1.0}
+    adjuvant_mapping = {idx: f"A{idx}" for idx in candidate_ids}
+    display_lookup = {f"A{idx}": f"Adj {idx}" for idx in candidate_ids}
+    class_lookup = {f"A{idx}": f"cls{idx}" for idx in candidate_ids}
+
+    metrics = ecs._compute_run_metrics(
+        run,
+        candidate_ids,
+        positives,
+        gains,
+        topk=(1, 3),
+        curve_k=4,
+        reliability_bins=2,
+        normalisation="minmax",
+        reliability_binning="equal_width",
+        adjuvant_mapping=adjuvant_mapping,
+        display_lookup=display_lookup,
+        class_lookup=class_lookup,
+    )
+
+    assert metrics["first_hit_rank"] == 1
+    assert metrics["mrr"] == pytest.approx(1.0)
+    assert metrics["reliability"]["mode"] == "equal_width"
+    assert len(metrics["ndcg_curve_k"]) == 4
+    assert metrics["topk_list"][0]["adjuvant_id"] == "A0"
+    assert metrics["topk_list"][0]["relevance_binary"] == 1
+    assert metrics["topk_list"][1]["relevance_binary"] == 0
+    assert metrics["random_recall_multiplier"]["3"] == pytest.approx(4 / 3)

--- a/tests/test_export_case_study_legacy.py
+++ b/tests/test_export_case_study_legacy.py
@@ -1,0 +1,98 @@
+"""Regression check for loading legacy train_ranker checkpoints."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+# Ensure the repository root and src directory are on the import path.
+ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = ROOT / "src"
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+import export_case_study as ecs  # noqa: E402
+
+
+class DummyGraph:
+    """Minimal stand-in for the PyG HeteroData object."""
+
+    node_types = ("disease", "adjuvant")
+
+    def __init__(self, feat_dim: int = 8, mech_dim: int = 0) -> None:
+        adjuvant_structured = (
+            torch.zeros(3, mech_dim, dtype=torch.float32) if mech_dim > 0 else None
+        )
+        self._nodes = {
+            "disease": SimpleNamespace(x=torch.zeros(2, feat_dim, dtype=torch.float32)),
+            "adjuvant": SimpleNamespace(
+                x=torch.zeros(4, feat_dim, dtype=torch.float32), structured=adjuvant_structured
+            ),
+        }
+
+    def __getitem__(self, key: str) -> SimpleNamespace:
+        return self._nodes[key]
+
+    def metadata(self) -> tuple:
+        return (list(self.node_types), [("disease", "rel", "adjuvant")])
+
+
+class DummyEncoder:
+    """Tracks whether ``load_state_dict`` was called."""
+
+    last_instance: "DummyEncoder | None" = None
+
+    def __init__(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
+        self.state_loaded = False
+        DummyEncoder.last_instance = self
+
+    def load_state_dict(self, state):  # type: ignore[no-untyped-def]
+        self.state_loaded = True
+        self.state = state
+
+    def to(self, device):  # type: ignore[no-untyped-def]
+        return self
+
+    def eval(self):  # type: ignore[no-untyped-def]
+        return self
+
+
+class FailingDualRanker:
+    def __init__(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
+        raise AssertionError("Modern DualRanker should not be constructed for legacy checkpoints")
+
+
+def test_legacy_checkpoint_falls_back_to_dot_product(monkeypatch, tmp_path, capsys):
+    """Exporter should accept the legacy checkpoint layout and emit a warning."""
+
+    ckpt_path = tmp_path / "legacy.pt"
+    legacy_args = {"data_path": "dummy.csv", "hidden_dim": 8}
+    legacy_state = {"encoder.weight": torch.zeros(1)}
+    torch.save({"state_dict": legacy_state, "args": legacy_args}, ckpt_path)
+
+    checkpoint = ecs._load_checkpoint(ckpt_path)
+    assert checkpoint["_legacy_listnet_head"] is True
+
+    monkeypatch.setattr(ecs, "PyGHeteroEncoder", DummyEncoder)
+    monkeypatch.setattr(ecs, "DualRanker", FailingDualRanker)
+
+    graph = DummyGraph()
+    model, ranking_head, adjuvant_mechanism = ecs._build_model(
+        graph,
+        checkpoint["args"],
+        checkpoint,
+        torch.device("cpu"),
+    )
+
+    captured = capsys.readouterr()
+    assert "legacy dot-product" in captured.out
+    assert isinstance(ranking_head, ecs.LegacyListNetRanker)
+    assert isinstance(model, DummyEncoder)
+    assert model.state_loaded is True
+    assert adjuvant_mechanism is None

--- a/train_disease_ranker.py
+++ b/train_disease_ranker.py
@@ -112,6 +112,16 @@ IMMUNE_PROFILE_DIM = len(IMMUNE_PROFILE_KEYWORDS)
 RECEPTOR_DIM = len(RECEPTOR_KEYWORDS)
 STRUCTURED_ADJUVANT_DIM = IMMUNE_PROFILE_DIM + RECEPTOR_DIM
 
+# Optional structured cues for diseases (mirrors adjuvant keywords so the
+# mechanism scorer can align receptors/immune profiles across both sides).
+DISEASE_MECHANISM_KEYWORDS = OrderedDict()
+for key, synonyms in IMMUNE_PROFILE_KEYWORDS.items():
+    DISEASE_MECHANISM_KEYWORDS[f"immune_{key}"] = synonyms
+for key, synonyms in RECEPTOR_KEYWORDS.items():
+    DISEASE_MECHANISM_KEYWORDS[f"receptor_{key}"] = synonyms
+
+DISEASE_STRUCTURED_DIM = len(DISEASE_MECHANISM_KEYWORDS)
+
 
 def set_global_seed(seed: int) -> None:
     """Seed ``random`` and PyTorch for reproducibility."""
@@ -908,6 +918,8 @@ def evaluate_disease_ranking(
     candidate_ids: Sequence[int],
     ranking_head: torch.nn.Module,
     ks: Sequence[int],
+    *,
+    adjuvant_mechanism: Optional[Tensor] = None,
 ) -> Dict[str, Dict[str, float]]:
     """
     Evaluate disease→adjuvant ranking performance.
@@ -948,7 +960,12 @@ def evaluate_disease_ranking(
         
         # Score using DualRanker's score_dis() (Bilinear layer)
         with torch.no_grad():
-            scores = ranking_head.score_dis(disease_batched, candidates_batched)  # [1, K]
+            mech_vec = None
+            if adjuvant_mechanism is not None and adjuvant_mechanism.numel() > 0:
+                mech_vec = adjuvant_mechanism[candidate_tensor].unsqueeze(0)
+            scores = ranking_head.score_dis(
+                disease_batched, candidates_batched, mech_vec
+            )  # [1, K]
             scores = scores.squeeze(0)  # [K]
         
         # Rank candidates by score (descending)
@@ -1095,6 +1112,7 @@ def build_graph(
     *,
     text_encoder: Optional[Tuple["PreTrainedTokenizerBase", "PreTrainedModel"]] = None,
     text_encoder_config: Optional[Mapping[str, object]] = None,
+    enable_disease_structured: bool = False,
 ) -> Tuple[
     HeteroData,
     Dict[str, Dict[object, int]],
@@ -1137,6 +1155,7 @@ def build_graph(
 
     disease_texts: List[str] = []
     disease_grouped = df.groupby("disease_key")
+    disease_structured_vectors: List[List[float]] = []
     for disease_name in disease_names:
         group = disease_grouped.get_group(disease_name)
         parts = [
@@ -1144,6 +1163,20 @@ def build_graph(
             _aggregate_series(group["pathogen_name"]) if "pathogen_name" in group else "",
         ]
         disease_texts.append(" ".join(filter(None, parts)))
+        if enable_disease_structured and DISEASE_STRUCTURED_DIM:
+            mechanism_sources: List[str] = []
+            mechanism_sources.append(_safe_text(disease_name))
+            mechanism_sources.extend(_collect_group_strings(group, "pathogen_name"))
+            for column in (
+                "disease_notes",
+                "disease_category",
+                "disease_description",
+            ):
+                if column in group:
+                    mechanism_sources.extend(_collect_group_strings(group, column))
+            disease_structured_vectors.append(
+                _multi_hot_from_keywords(mechanism_sources, DISEASE_MECHANISM_KEYWORDS)
+            )
 
     platform_texts: List[str] = []
     platform_grouped = df.groupby("platform_group")
@@ -1315,11 +1348,24 @@ def build_graph(
         },
     )
 
+    if enable_disease_structured and disease_structured_vectors:
+        disease_structured = torch.tensor(disease_structured_vectors, dtype=torch.float32)
+    else:
+        disease_structured = torch.zeros((len(disease_names), 0), dtype=torch.float32)
+
+    if disease_structured.size(1):
+        print("Structured disease feature dims:", {"mechanism": disease_structured.size(1)})
+
     graph = HeteroData()
 
     if text_encoder is None:
         graph["vaccine"].x = hashed_text_features(vaccine_texts, feature_dim)
-        graph["disease"].x = hashed_text_features(disease_texts, feature_dim)
+        disease_hashed = hashed_text_features(disease_texts, feature_dim)
+        if disease_structured.size(1):
+            combined_dis = torch.cat([disease_hashed, disease_structured], dim=1)
+            graph["disease"].x = _layer_norm_features(combined_dis)
+        else:
+            graph["disease"].x = disease_hashed
         graph["platform"].x = hashed_text_features(platform_texts, feature_dim)
         adjuvant_hashed = hashed_text_features(adjuvant_texts, feature_dim)
         if adjuvant_structured.size(1):
@@ -1372,6 +1418,9 @@ def build_graph(
             device=device,
             normalize=normalize,
         )
+        if disease_structured.size(1):
+            combined_dis = torch.cat([graph["disease"].x, disease_structured], dim=1)
+            graph["disease"].x = _layer_norm_features(combined_dis)
         graph["platform"].x = encode_with_transformer(
             platform_texts,
             tokenizer,
@@ -1395,6 +1444,9 @@ def build_graph(
         if adjuvant_structured.size(1):
             combined = torch.cat([graph["adjuvant"].x, adjuvant_structured], dim=1)
             graph["adjuvant"].x = _layer_norm_features(combined)
+
+    graph["adjuvant"].structured = adjuvant_structured
+    graph["disease"].structured = disease_structured
 
     for edge_type, edge_list in edges.items():
         if edge_list:
@@ -1702,6 +1754,19 @@ def train_one_split(
     node_feat_dims = {
         node_type: features.size(1) for node_type, features in graph.x_dict.items()
     }
+    adjuvant_structured = getattr(train_graph["adjuvant"], "structured", None)
+    adjuvant_mechanism_dim = (
+        int(adjuvant_structured.size(1))
+        if isinstance(adjuvant_structured, Tensor)
+        else 0
+    )
+    use_mechanism = args.enable_disease_mechanism_cues and adjuvant_mechanism_dim > 0
+    if args.enable_disease_mechanism_cues and not use_mechanism:
+        print(
+            "Warning: disease mechanism cues enabled but no adjuvant structured features "
+            "were found; falling back to bilinear scorer."
+        )
+
     model = PyGHeteroEncoder(
         node_feat_dims,
         graph.metadata(),
@@ -1712,9 +1777,9 @@ def train_one_split(
         args.appnp_alpha,
         args.appnp_dropout,
     )
-    
+
     # NEW: Use DualRanker instead of ListNetRankingHead for disease head support
-    mech_in_dim = None  # TODO: set to actual mechanism vector dim if using mechanism-aware scoring
+    mech_in_dim = adjuvant_mechanism_dim if use_mechanism else None
     ranking_head = DualRanker(args.hidden_dim, mech_in_dim, args.gamma_mech).to(device)
     link_head = LinkPredictionHead(args.self_adversarial_temperature).to(device)
 
@@ -1728,6 +1793,13 @@ def train_one_split(
     optimizer = torch.optim.AdamW(param_groups, weight_decay=args.weight_decay)
 
     train_graph_device = train_graph.to(device)
+    adjuvant_mechanism_device: Optional[Tensor]
+    if use_mechanism:
+        adjuvant_mechanism_device = getattr(
+            train_graph_device["adjuvant"], "structured", None
+        )
+    else:
+        adjuvant_mechanism_device = None
     model = model.to(device)
     results: Dict[str, Dict[str, float]] = {}
     best_val = -float("inf")
@@ -1796,6 +1868,7 @@ def train_one_split(
                 device,
                 ndcg_tau=args.disease_ndcg_tau,
                 ndcg_topk=ndcg_topk,
+                adjuvant_mechanism=adjuvant_mechanism_device,
             )
 
             rank_loss_dis = (
@@ -1834,7 +1907,8 @@ def train_one_split(
         if val_diseases and args.lambda_disease > 0:
             val_dis_metrics = evaluate_disease_ranking(
                 embeddings, val_diseases, disease_positives_lookup,
-                candidate_ids, ranking_head, (5, 10)
+                candidate_ids, ranking_head, (5, 10),
+                adjuvant_mechanism=adjuvant_mechanism_device,
             )
         
         print(
@@ -1860,9 +1934,14 @@ def train_one_split(
         checkpoint_dir.mkdir(parents=True, exist_ok=True)
         checkpoint_path = checkpoint_dir / f"{scheme}_best.pt"
         cpu_state = {key: tensor.cpu() for key, tensor in best_state.items()}
+        ranking_state = {
+            key: value.cpu()
+            for key, value in ranking_head.state_dict().items()
+        }
         torch.save(
             {
                 "state_dict": cpu_state,
+                "ranking_head_state_dict": ranking_state,
                 "metadata": graph.metadata(),
                 "mappings": mappings,
                 "args": vars(args),
@@ -1900,22 +1979,37 @@ def train_one_split(
         # Compute disease train metrics
         if train_diseases:
             disease_train_metrics = evaluate_disease_ranking(
-                embeddings, train_diseases, disease_positives_lookup,
-                candidate_ids, ranking_head, (5, 10)
+                embeddings,
+                train_diseases,
+                disease_positives_lookup,
+                candidate_ids,
+                ranking_head,
+                (5, 10),
+                adjuvant_mechanism=adjuvant_mechanism_device,
             )
 
         # Compute disease val metrics
         if val_diseases:
             disease_val_metrics = evaluate_disease_ranking(
-                embeddings, val_diseases, disease_positives_lookup,
-                candidate_ids, ranking_head, (5, 10)
+                embeddings,
+                val_diseases,
+                disease_positives_lookup,
+                candidate_ids,
+                ranking_head,
+                (5, 10),
+                adjuvant_mechanism=adjuvant_mechanism_device,
             )
 
         # Compute disease test metrics (for inductive split)
         if test_diseases:
             disease_test_metrics = evaluate_disease_ranking(
-                embeddings, test_diseases, disease_positives_lookup,
-                candidate_ids, ranking_head, (5, 10)
+                embeddings,
+                test_diseases,
+                disease_positives_lookup,
+                candidate_ids,
+                ranking_head,
+                (5, 10),
+                adjuvant_mechanism=adjuvant_mechanism_device,
             )
 
     if disease_positives_lookup:
@@ -2170,6 +2264,14 @@ def parse_args() -> argparse.Namespace:
         help="Weight for mechanism-aware compatibility scoring in disease head (NEW)",
     )
     parser.add_argument(
+        "--enable-disease-mechanism-cues",
+        action="store_true",
+        help=(
+            "Augment disease nodes with curated receptor/immune multi-hot features and "
+            "activate the mechanism-aware disease→adjuvant scorer"
+        ),
+    )
+    parser.add_argument(
         "--disease-batch-size",
         type=int,
         default=32,
@@ -2285,6 +2387,7 @@ def main() -> None:
         args.feature_dim,
         text_encoder=text_encoder,
         text_encoder_config=text_encoder_config,
+        enable_disease_structured=args.enable_disease_mechanism_cues,
     )
 
     if hf_model is not None:

--- a/train_disease_ranker.py
+++ b/train_disease_ranker.py
@@ -23,7 +23,6 @@ training on larger graphs.
 from __future__ import annotations
 
 import argparse
-import copy
 import hashlib
 import json
 import math
@@ -1804,6 +1803,7 @@ def train_one_split(
     results: Dict[str, Dict[str, float]] = {}
     best_val = -float("inf")
     best_state: Optional[Dict[str, Tensor]] = None
+    best_ranking_state: Optional[Dict[str, Tensor]] = None
     patience_counter = 0
 
     for epoch in range(1, args.epochs + 1):
@@ -1921,35 +1921,55 @@ def train_one_split(
         if score > best_val:
             best_val = score
             patience_counter = 0
-            best_state = copy.deepcopy(model.state_dict())
+            best_state = {
+                key: value.detach().cpu()
+                for key, value in model.state_dict().items()
+            }
+            best_ranking_state = {
+                key: value.detach().cpu()
+                for key, value in ranking_head.state_dict().items()
+            }
         else:
             patience_counter += 1
             if patience_counter >= args.patience:
                 print("Early stopping triggered")
                 break
 
-    if best_state is not None:
+    if best_state is None:
+        best_state = {
+            key: value.detach().cpu()
+            for key, value in model.state_dict().items()
+        }
+    else:
         model.load_state_dict(best_state)
-        checkpoint_dir = args.output_dir / "checkpoints"
-        checkpoint_dir.mkdir(parents=True, exist_ok=True)
-        checkpoint_path = checkpoint_dir / f"{scheme}_best.pt"
-        cpu_state = {key: tensor.cpu() for key, tensor in best_state.items()}
-        ranking_state = {
-            key: value.cpu()
+
+    if best_ranking_state is None:
+        best_ranking_state = {
+            key: value.detach().cpu()
             for key, value in ranking_head.state_dict().items()
         }
-        torch.save(
-            {
-                "state_dict": cpu_state,
-                "ranking_head_state_dict": ranking_state,
-                "metadata": graph.metadata(),
-                "mappings": mappings,
-                "args": vars(args),
-                "split": scheme,
-            },
-            checkpoint_path,
-        )
-        print(f"Saved best checkpoint to {checkpoint_path}")
+    else:
+        ranking_head.load_state_dict(best_ranking_state)
+
+    checkpoint_dir = args.output_dir / "checkpoints"
+    checkpoint_dir.mkdir(parents=True, exist_ok=True)
+    checkpoint_path = checkpoint_dir / f"{scheme}_best.pt"
+    cpu_state = {key: tensor.cpu() for key, tensor in best_state.items()}
+    ranking_state = {
+        key: value.cpu() for key, value in best_ranking_state.items()
+    }
+    torch.save(
+        {
+            "state_dict": cpu_state,
+            "ranking_head_state_dict": ranking_state,
+            "metadata": graph.metadata(),
+            "mappings": mappings,
+            "args": vars(args),
+            "split": scheme,
+        },
+        checkpoint_path,
+    )
+    print(f"Saved best checkpoint to {checkpoint_path}")
 
     model.eval()
     with torch.no_grad():

--- a/train_disease_ranker.py
+++ b/train_disease_ranker.py
@@ -975,6 +975,88 @@ def evaluate_disease_ranking(
     return {"macro": macro, "per_query": per_query}
 
 
+def evaluate_disease_via_vaccines(
+    embeddings: Mapping[str, Tensor],
+    disease_indices: Sequence[int],
+    disease_to_vaccines: Mapping[int, Sequence[int]],
+    disease_positives: Mapping[int, Sequence[int]],
+    candidate_ids: Sequence[int],
+    aggregation: str,
+    ks: Sequence[int],
+) -> Dict[str, Dict[str, float]]:
+    """Evaluate disease→adjuvant ranking by aggregating vaccine scores.
+
+    Args:
+        embeddings: Learned node embeddings.
+        disease_indices: Disease query indices for this split.
+        disease_to_vaccines: Mapping of disease index → vaccine indices associated
+            with that disease within the split.
+        disease_positives: Mapping of disease index → positive adjuvant indices.
+        candidate_ids: Candidate adjuvant indices considered for ranking.
+        aggregation: Aggregation strategy (``"max"`` or ``"mean"``) used to merge
+            vaccine-level scores into disease-level scores.
+        ks: Top-k cut-offs for metrics.
+
+    Returns:
+        Dictionary mirroring :func:`evaluate_disease_ranking` with ``macro`` and
+        ``per_query`` sections.
+    """
+
+    if aggregation not in {"max", "mean"}:
+        raise ValueError(
+            "aggregation must be either 'max' or 'mean' for vaccine-to-disease evaluation"
+        )
+
+    vaccine_repr = embeddings["vaccine"]
+    adjuvant_repr = embeddings["adjuvant"]
+    device = vaccine_repr.device
+
+    candidate_tensor = torch.tensor(candidate_ids, dtype=torch.long, device=device)
+    candidate_vectors = adjuvant_repr[candidate_tensor]
+
+    metrics = {f"ndcg@{k}": [] for k in ks}
+    metrics.update({f"recall@{k}": [] for k in ks})
+    per_query: Dict[str, Dict[str, float]] = {}
+
+    for disease_idx in disease_indices:
+        positives = disease_positives.get(disease_idx, [])
+        vaccine_indices = disease_to_vaccines.get(disease_idx, [])
+        if not positives or not vaccine_indices:
+            continue
+
+        vaccine_tensor = torch.tensor(vaccine_indices, dtype=torch.long, device=device)
+        vaccine_vectors = vaccine_repr[vaccine_tensor]
+        scores = torch.matmul(vaccine_vectors, candidate_vectors.t())  # [num_vaccines, K]
+
+        if aggregation == "max":
+            agg_scores = scores.max(dim=0).values
+        else:  # aggregation == "mean"
+            agg_scores = scores.mean(dim=0)
+
+        order = torch.argsort(agg_scores, descending=True)
+        ranked_candidates = candidate_tensor[order].tolist()
+        positive_list = list(positives)
+
+        query_metrics: Dict[str, float] = {}
+        for k in ks:
+            ndcg_value = ndcg_at_k(ranked_candidates, positive_list, k)
+            recall_value = recall_at_k(ranked_candidates, positive_list, k)
+            metrics[f"ndcg@{k}"].append(ndcg_value)
+            metrics[f"recall@{k}"].append(recall_value)
+            query_metrics[f"ndcg@{k}"] = ndcg_value
+            query_metrics[f"recall@{k}"] = recall_value
+
+        if query_metrics:
+            per_query[str(disease_idx)] = query_metrics
+
+    macro = {
+        name: float(np.mean(values)) if values else 0.0
+        for name, values in metrics.items()
+    }
+
+    return {"macro": macro, "per_query": per_query}
+
+
 def evaluate_link_prediction(
     embeddings: Mapping[str, Tensor],
     edges: Sequence[Tuple[int, int]],
@@ -1529,6 +1611,23 @@ def train_one_split(
                     indices.add(idx)
         return sorted(indices)
 
+    def _disease_to_vaccines(
+        entries: Sequence[Mapping[str, object]]
+    ) -> Dict[int, List[int]]:
+        mapping: Dict[int, Set[int]] = {}
+        for entry in entries:
+            vaccine_id = entry.get("vaccine_id")
+            if vaccine_id not in mappings["vaccine"]:
+                continue
+            vaccine_idx = mappings["vaccine"][vaccine_id]
+            diseases = entry.get("diseases") or []
+            for disease in diseases:
+                disease_idx = mappings["disease"].get(disease)
+                if disease_idx is None:
+                    continue
+                mapping.setdefault(disease_idx, set()).add(vaccine_idx)
+        return {key: sorted(values) for key, values in mapping.items()}
+
     train_vaccines = [
         mappings["vaccine"][entry["vaccine_id"]]
         for entry in manifests["train"]
@@ -1551,6 +1650,10 @@ def train_one_split(
     train_diseases = _collect_diseases(manifests.get("train", []))
     val_diseases = _collect_diseases(manifests.get("val", []))
     test_diseases = _collect_diseases(manifests.get("test", []))
+
+    train_disease_to_vaccines = _disease_to_vaccines(manifests.get("train", []))
+    val_disease_to_vaccines = _disease_to_vaccines(manifests.get("val", []))
+    test_disease_to_vaccines = _disease_to_vaccines(manifests.get("test", []))
 
     train_graph = restrict_label_edges_for_training(graph, train_vaccines)
     train_graph = restrict_context_edges_for_training(
@@ -1782,6 +1885,9 @@ def train_one_split(
     disease_train_metrics = {"macro": {}, "per_query": {}}
     disease_val_metrics = {"macro": {}, "per_query": {}}
     disease_test_metrics = {"macro": {}, "per_query": {}}
+    vaccine_agg_train = {"macro": {}, "per_query": {}}
+    vaccine_agg_val = {"macro": {}, "per_query": {}}
+    vaccine_agg_test = {"macro": {}, "per_query": {}}
 
     if disease_positives_lookup and args.lambda_disease > 0:
         # Compute disease train metrics
@@ -1803,6 +1909,38 @@ def train_one_split(
             disease_test_metrics = evaluate_disease_ranking(
                 embeddings, test_diseases, disease_positives_lookup,
                 candidate_ids, ranking_head, (5, 10)
+            )
+
+    if disease_positives_lookup:
+        if train_diseases:
+            vaccine_agg_train = evaluate_disease_via_vaccines(
+                embeddings,
+                train_diseases,
+                train_disease_to_vaccines,
+                disease_positives_lookup,
+                candidate_ids,
+                args.disease_baseline_aggregation,
+                (5, 10),
+            )
+        if val_diseases:
+            vaccine_agg_val = evaluate_disease_via_vaccines(
+                embeddings,
+                val_diseases,
+                val_disease_to_vaccines,
+                disease_positives_lookup,
+                candidate_ids,
+                args.disease_baseline_aggregation,
+                (5, 10),
+            )
+        if test_diseases:
+            vaccine_agg_test = evaluate_disease_via_vaccines(
+                embeddings,
+                test_diseases,
+                test_disease_to_vaccines,
+                disease_positives_lookup,
+                candidate_ids,
+                args.disease_baseline_aggregation,
+                (5, 10),
             )
 
     link_metrics: Dict[str, Dict[str, float]] = {}
@@ -1856,7 +1994,22 @@ def train_one_split(
         results["disease_ranking_test"] = disease_test_metrics["macro"]
     if disease_test_metrics["per_query"]:
         results["disease_ranking_test_per_query"] = disease_test_metrics["per_query"]
-    
+
+    if vaccine_agg_train["macro"]:
+        results["disease_from_vaccine_train"] = vaccine_agg_train["macro"]
+    if vaccine_agg_train["per_query"]:
+        results["disease_from_vaccine_train_per_query"] = vaccine_agg_train["per_query"]
+    if vaccine_agg_val["macro"]:
+        results["disease_from_vaccine_val"] = vaccine_agg_val["macro"]
+    if vaccine_agg_val["per_query"]:
+        results["disease_from_vaccine_val_per_query"] = vaccine_agg_val["per_query"]
+    if vaccine_agg_test["macro"]:
+        results["disease_from_vaccine_test"] = vaccine_agg_test["macro"]
+    if vaccine_agg_test["per_query"]:
+        results["disease_from_vaccine_test_per_query"] = vaccine_agg_test["per_query"]
+
+    results["disease_from_vaccine_aggregation"] = args.disease_baseline_aggregation
+
     return results
 
 
@@ -1969,6 +2122,15 @@ def parse_args() -> argparse.Namespace:
         type=float,
         default=1.0,
         help="Weight for the disease→adjuvant ranking loss (NEW for disease head)",
+    )
+    parser.add_argument(
+        "--disease-baseline-aggregation",
+        choices=["max", "mean"],
+        default="max",
+        help=(
+            "Aggregation rule for deriving disease-level scores from the vaccine "
+            "head when computing the non-inferiority baseline"
+        ),
     )
     parser.add_argument(
         "--gamma-mech",

--- a/train_disease_ranker.py
+++ b/train_disease_ranker.py
@@ -46,7 +46,7 @@ from disease_head_utils import (
     load_disease_positives,
     sample_disease_batch,
     build_vo_class_lookup,
-    listnet_loss_disease,
+    disease_ranking_losses,
 )
 
 try:
@@ -1773,35 +1773,42 @@ def train_one_split(
         # NEW: Disease batch sampling and training (inline after vaccine batches)
         if args.lambda_disease > 0 and train_diseases:
             # Sample one disease batch per epoch
-            from src.disease_head_utils import sample_disease_batch, listnet_loss_disease
             disease_batch = sample_disease_batch(
-                train_diseases, 
+                train_diseases,
                 disease_positives_lookup=disease_positives_lookup,
                 all_adjuvant_indices=list(candidate_ids),
                 batch_size=min(args.disease_batch_size, len(train_diseases)),
                 max_positives=args.list_size,
                 num_negatives=args.list_size
             )
-            
+
             # Compute disease head loss
             optimizer.zero_grad()
             embeddings = model(train_graph_device)
-            
-            # Disease→adjuvant ranking loss using ListNet
-            rank_loss_dis = listnet_loss_disease(
+
+            ndcg_topk = (
+                args.disease_ndcg_topk if args.disease_ndcg_topk > 0 else None
+            )
+            ndcg_loss_dis, listnet_loss_dis = disease_ranking_losses(
                 embeddings,
                 disease_batch,
-                ranking_head,  # DualRanker instance with score_dis() method
-                device
+                ranking_head,
+                device,
+                ndcg_tau=args.disease_ndcg_tau,
+                ndcg_topk=ndcg_topk,
             )
-            
+
+            rank_loss_dis = (
+                args.disease_ndcg_weight * ndcg_loss_dis
+                + args.disease_listnet_weight * listnet_loss_dis
+            )
             loss_dis = args.lambda_disease * rank_loss_dis
-            if loss_dis.item() > 0:
+            if loss_dis.requires_grad:
                 loss_dis.backward()
                 if args.clip_grad > 0:
                     torch.nn.utils.clip_grad_norm_(model.parameters(), args.clip_grad)
                 optimizer.step()
-                
+
                 total_loss += loss_dis.item()
                 total_rank_dis += rank_loss_dis.item()
 
@@ -2122,6 +2129,30 @@ def parse_args() -> argparse.Namespace:
         type=float,
         default=1.0,
         help="Weight for the disease→adjuvant ranking loss (NEW for disease head)",
+    )
+    parser.add_argument(
+        "--disease-ndcg-weight",
+        type=float,
+        default=1.0,
+        help="Weight applied to the ApproxNDCG surrogate in the disease head loss",
+    )
+    parser.add_argument(
+        "--disease-listnet-weight",
+        type=float,
+        default=0.2,
+        help="Stability weight for the legacy ListNet disease loss component",
+    )
+    parser.add_argument(
+        "--disease-ndcg-topk",
+        type=int,
+        default=50,
+        help="Number of top-scoring adjuvants per disease used in the ApproxNDCG loss",
+    )
+    parser.add_argument(
+        "--disease-ndcg-tau",
+        type=float,
+        default=1.0,
+        help="Temperature for the sigmoid approximation of ranks in ApproxNDCG",
     )
     parser.add_argument(
         "--disease-baseline-aggregation",

--- a/train_disease_ranker.py
+++ b/train_disease_ranker.py
@@ -864,7 +864,7 @@ def evaluate_ranking(
     positives: Mapping[int, Sequence[int]],
     candidate_ids: Sequence[int],
     ks: Sequence[int],
-) -> Dict[str, float]:
+) -> Dict[str, Dict[str, float]]:
     adjuvant_repr = embeddings["adjuvant"]
     vaccine_repr = embeddings["vaccine"]
     candidate_tensor = torch.tensor(candidate_ids, dtype=torch.long, device=adjuvant_repr.device)
@@ -872,6 +872,7 @@ def evaluate_ranking(
 
     metrics = {f"ndcg@{k}": [] for k in ks}
     metrics.update({f"recall@{k}": [] for k in ks})
+    per_query: Dict[str, Dict[str, float]] = {}
 
     for vaccine_idx in vaccine_indices:
         if vaccine_idx not in positives:
@@ -881,14 +882,23 @@ def evaluate_ranking(
         order = torch.argsort(scores, descending=True)
         ranked_candidates = candidate_tensor[order].tolist()
         positive_list = list(positives[vaccine_idx])
+        query_metrics: Dict[str, float] = {}
         for k in ks:
-            metrics[f"ndcg@{k}"].append(ndcg_at_k(ranked_candidates, positive_list, k))
-            metrics[f"recall@{k}"].append(recall_at_k(ranked_candidates, positive_list, k))
+            ndcg_value = ndcg_at_k(ranked_candidates, positive_list, k)
+            recall_value = recall_at_k(ranked_candidates, positive_list, k)
+            metrics[f"ndcg@{k}"].append(ndcg_value)
+            metrics[f"recall@{k}"].append(recall_value)
+            query_metrics[f"ndcg@{k}"] = ndcg_value
+            query_metrics[f"recall@{k}"] = recall_value
+        if query_metrics:
+            per_query[str(vaccine_idx)] = query_metrics
 
-    return {
+    macro = {
         name: float(np.mean(values)) if values else 0.0
         for name, values in metrics.items()
     }
+
+    return {"macro": macro, "per_query": per_query}
 
 
 def evaluate_disease_ranking(
@@ -898,7 +908,7 @@ def evaluate_disease_ranking(
     candidate_ids: Sequence[int],
     ranking_head: torch.nn.Module,
     ks: Sequence[int],
-) -> Dict[str, float]:
+) -> Dict[str, Dict[str, float]]:
     """
     Evaluate disease→adjuvant ranking performance.
     
@@ -911,7 +921,10 @@ def evaluate_disease_ranking(
         ks: Top-K values for metrics (e.g., [5, 10])
     
     Returns:
-        Dict with keys like "ndcg@5", "ndcg@10", "recall@5", "recall@10"
+        Dictionary with two sections:
+
+        * ``macro`` – mean metrics across diseases.
+        * ``per_query`` – mapping of disease index (as a string) to per-metric scores.
     """
     disease_repr = embeddings["disease"]
     adjuvant_repr = embeddings["adjuvant"]
@@ -921,7 +934,8 @@ def evaluate_disease_ranking(
     
     metrics = {f"ndcg@{k}": [] for k in ks}
     metrics.update({f"recall@{k}": [] for k in ks})
-    
+    per_query: Dict[str, Dict[str, float]] = {}
+
     for disease_idx in disease_indices:
         positives = disease_positives.get(disease_idx, [])
         if not positives:
@@ -942,14 +956,23 @@ def evaluate_disease_ranking(
         ranked_candidates = candidate_tensor[order].tolist()
         positive_list = list(positives)
         
+        query_metrics: Dict[str, float] = {}
         for k in ks:
-            metrics[f"ndcg@{k}"].append(ndcg_at_k(ranked_candidates, positive_list, k))
-            metrics[f"recall@{k}"].append(recall_at_k(ranked_candidates, positive_list, k))
-    
-    return {
+            ndcg_value = ndcg_at_k(ranked_candidates, positive_list, k)
+            recall_value = recall_at_k(ranked_candidates, positive_list, k)
+            metrics[f"ndcg@{k}"].append(ndcg_value)
+            metrics[f"recall@{k}"].append(recall_value)
+            query_metrics[f"ndcg@{k}"] = ndcg_value
+            query_metrics[f"recall@{k}"] = recall_value
+        if query_metrics:
+            per_query[str(disease_idx)] = query_metrics
+
+    macro = {
         name: float(np.mean(values)) if values else 0.0
         for name, values in metrics.items()
     }
+
+    return {"macro": macro, "per_query": per_query}
 
 
 def evaluate_link_prediction(
@@ -1692,22 +1715,23 @@ def train_one_split(
         val_metrics = (
             evaluate_ranking(embeddings, val_vaccines, positives_lookup, candidate_ids, (5, 10))
             if val_vaccines
-            else {"ndcg@5": 0.0, "ndcg@10": 0.0}
+            else {"macro": {"ndcg@5": 0.0, "ndcg@10": 0.0}, "per_query": {}}
         )
-        score = val_metrics.get("ndcg@10", 0.0)
-        
+        score = val_metrics["macro"].get("ndcg@10", 0.0)
+
         # Disease head validation (NEW)
-        val_dis_metrics = {}
+        val_dis_metrics = {"macro": {}, "per_query": {}}
         if val_diseases and args.lambda_disease > 0:
             val_dis_metrics = evaluate_disease_ranking(
-                embeddings, val_diseases, disease_positives_lookup, 
+                embeddings, val_diseases, disease_positives_lookup,
                 candidate_ids, ranking_head, (5, 10)
             )
         
         print(
             f"Epoch {epoch:03d} | loss={avg_loss:.4f} "
             f"vax_rank={avg_rank_vax:.4f} dis_rank={avg_rank_dis:.4f} lp={avg_lp:.4f} | "
-            f"val_vax_ndcg10={score:.4f} val_dis_ndcg10={val_dis_metrics.get('ndcg@10', 0.0):.4f}"
+            f"val_vax_ndcg10={score:.4f} "
+            f"val_dis_ndcg10={val_dis_metrics['macro'].get('ndcg@10', 0.0):.4f}"
         )
 
         if score > best_val:
@@ -1746,19 +1770,19 @@ def train_one_split(
     val_metrics = (
         evaluate_ranking(embeddings, val_vaccines, positives_lookup, candidate_ids, (5, 10))
         if val_vaccines
-        else {}
+        else {"macro": {}, "per_query": {}}
     )
     test_metrics = (
         evaluate_ranking(embeddings, test_vaccines, positives_lookup, candidate_ids, (5, 10))
         if test_vaccines
-        else {}
+        else {"macro": {}, "per_query": {}}
     )
 
     # Disease head evaluation (NEW)
-    disease_train_metrics = {}
-    disease_val_metrics = {}
-    disease_test_metrics = {}
-    
+    disease_train_metrics = {"macro": {}, "per_query": {}}
+    disease_val_metrics = {"macro": {}, "per_query": {}}
+    disease_test_metrics = {"macro": {}, "per_query": {}}
+
     if disease_positives_lookup and args.lambda_disease > 0:
         # Compute disease train metrics
         if train_diseases:
@@ -1766,14 +1790,14 @@ def train_one_split(
                 embeddings, train_diseases, disease_positives_lookup,
                 candidate_ids, ranking_head, (5, 10)
             )
-        
+
         # Compute disease val metrics
         if val_diseases:
             disease_val_metrics = evaluate_disease_ranking(
                 embeddings, val_diseases, disease_positives_lookup,
                 candidate_ids, ranking_head, (5, 10)
             )
-        
+
         # Compute disease test metrics (for inductive split)
         if test_diseases:
             disease_test_metrics = evaluate_disease_ranking(
@@ -1805,21 +1829,33 @@ def train_one_split(
             embeddings, test_edges, positives_lookup, candidate_ids, (1, 3, 10)
         )
 
-    results["ranking_train"] = train_metrics
-    if val_metrics:
-        results["ranking_val"] = val_metrics
-    if test_metrics:
-        results["ranking_test"] = test_metrics
+    results["ranking_train"] = train_metrics["macro"]
+    if train_metrics["per_query"]:
+        results["ranking_train_per_query"] = train_metrics["per_query"]
+    if val_metrics["macro"]:
+        results["ranking_val"] = val_metrics["macro"]
+    if val_metrics["per_query"]:
+        results["ranking_val_per_query"] = val_metrics["per_query"]
+    if test_metrics["macro"]:
+        results["ranking_test"] = test_metrics["macro"]
+    if test_metrics["per_query"]:
+        results["ranking_test_per_query"] = test_metrics["per_query"]
     if link_metrics:
         results["link_prediction"] = link_metrics
     
     # Disease head results (NEW)
-    if disease_train_metrics:
-        results["disease_ranking_train"] = disease_train_metrics
-    if disease_val_metrics:
-        results["disease_ranking_val"] = disease_val_metrics
-    if disease_test_metrics:
-        results["disease_ranking_test"] = disease_test_metrics
+    if disease_train_metrics["macro"]:
+        results["disease_ranking_train"] = disease_train_metrics["macro"]
+    if disease_train_metrics["per_query"]:
+        results["disease_ranking_train_per_query"] = disease_train_metrics["per_query"]
+    if disease_val_metrics["macro"]:
+        results["disease_ranking_val"] = disease_val_metrics["macro"]
+    if disease_val_metrics["per_query"]:
+        results["disease_ranking_val_per_query"] = disease_val_metrics["per_query"]
+    if disease_test_metrics["macro"]:
+        results["disease_ranking_test"] = disease_test_metrics["macro"]
+    if disease_test_metrics["per_query"]:
+        results["disease_ranking_test_per_query"] = disease_test_metrics["per_query"]
     
     return results
 


### PR DESCRIPTION
## Summary
- return both macro averages and per-query metrics from the vaccine and disease ranking evaluators
- persist the per-query payloads next to the existing macro metrics when producing training results
- add `src/eval_ci.py` to compute bootstrap confidence intervals and paired randomization tests from stored metrics

## Testing
- python -m compileall train_disease_ranker.py src/eval_ci.py

------
https://chatgpt.com/codex/tasks/task_e_68e9d7b6538483219c895d062b026c2d

## Summary by Sourcery

Expose and persist detailed per-query ranking metrics in the training pipeline and introduce a new CI tooling script for statistical evaluation of stored results.

New Features:
- Expose per-query metrics alongside macro averages in vaccine and disease ranking evaluators
- Persist per-query metric payloads in the training result output
- Add eval_ci.py CLI tool to compute bootstrap confidence intervals and paired randomization tests

Enhancements:
- Refactor evaluation functions to return structured dictionaries with separate 'macro' and 'per_query' sections
- Update training pipeline to emit distinct result entries for macro and per-query metrics across train/val/test splits and ranking heads

Documentation:
- Enhance function docstrings to describe the new per-query and macro return format