### PR TITLE
Add legacy fallback handling in export case study script

### DIFF
--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -1,0 +1,2 @@
+"""Utilities and scripts for downstream analysis and visualisation."""
+

--- a/analysis/draw_case_study_panels.py
+++ b/analysis/draw_case_study_panels.py
@@ -1,0 +1,399 @@
+"""Generate the four-panel case-study figure from exporter outputs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, List, Mapping, MutableMapping, Optional, Sequence
+
+import matplotlib
+
+# Use a non-interactive backend so the script can run on headless machines.
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+
+def _ensure_run(summary: Mapping[str, object], label: str) -> Mapping[str, object]:
+    runs = summary.get("runs")
+    if not isinstance(runs, Mapping):
+        raise KeyError("Summary JSON is missing the 'runs' mapping.")
+    run = runs.get(label)
+    if run is None:
+        available = ", ".join(sorted(map(str, runs.keys())))
+        raise KeyError(f"Run label '{label}' not found. Available labels: {available}")
+    if not isinstance(run, Mapping):
+        raise TypeError(f"Run entry for label '{label}' must be a mapping.")
+    return run
+
+
+def _sorted_topk_keys(run_metrics: Mapping[str, object]) -> List[int]:
+    topk = run_metrics.get("topk", {})
+    if not isinstance(topk, Mapping):
+        return []
+    result: List[int] = []
+    for key in topk.keys():
+        try:
+            result.append(int(key))
+        except (TypeError, ValueError):
+            continue
+    return sorted(result)
+
+
+def _plot_topk_panel(ax: plt.Axes, run_metrics: Mapping[str, object]) -> None:
+    topk_list = run_metrics.get("topk_list", [])
+    if not isinstance(topk_list, Sequence) or len(topk_list) == 0:
+        ax.text(0.5, 0.5, "No Top-10 entries available", ha="center", va="center")
+        ax.set_axis_off()
+        return
+
+    labels: List[str] = []
+    scores: List[float] = []
+    relevance: List[int] = []
+    for entry in topk_list:
+        if not isinstance(entry, Mapping):
+            continue
+        labels.append(str(entry.get("adjuvant_label", entry.get("adjuvant_id", "?"))))
+        try:
+            scores.append(float(entry.get("score", 0.0)))
+        except (TypeError, ValueError):
+            scores.append(0.0)
+        relevance.append(int(entry.get("relevance_binary", 0)))
+
+    if not labels:
+        ax.text(0.5, 0.5, "No Top-10 entries available", ha="center", va="center")
+        ax.set_axis_off()
+        return
+
+    y_positions = np.arange(len(labels))
+    colors = ["#1b9e77" if rel else "#cccccc" for rel in relevance]
+    ax.barh(y_positions, scores, color=colors)
+    ax.set_yticks(y_positions)
+    ax.set_yticklabels([f"#{rank + 1} {label}" for rank, label in enumerate(labels)])
+    ax.invert_yaxis()
+    ax.set_xlabel("Model score")
+    ax.set_title("Panel A – Top-10 ranking")
+
+    for idx, (score, rel) in enumerate(zip(scores, relevance)):
+        if rel:
+            ax.text(
+                score,
+                idx,
+                " ✓",
+                ha="left",
+                va="center",
+                color="#1b9e77",
+                fontsize=10,
+                fontweight="bold",
+            )
+
+    topk_metrics = run_metrics.get("topk", {})
+    if isinstance(topk_metrics, Mapping):
+        lines: List[str] = []
+        for k in _sorted_topk_keys(run_metrics):
+            metrics = topk_metrics.get(str(k), {})
+            if not isinstance(metrics, Mapping):
+                continue
+            precision = metrics.get("precision")
+            recall = metrics.get("recall")
+            ndcg = metrics.get("ndcg")
+            if isinstance(precision, (int, float)):
+                lines.append(f"P@{k}: {precision:.3f}")
+            if isinstance(recall, (int, float)):
+                lines.append(f"R@{k}: {recall:.3f}")
+            if isinstance(ndcg, (int, float)):
+                lines.append(f"NDCG@{k}: {ndcg:.3f}")
+        if lines:
+            ax.text(
+                0.98,
+                0.02,
+                "\n".join(lines),
+                transform=ax.transAxes,
+                ha="right",
+                va="bottom",
+                fontsize=9,
+                bbox=dict(boxstyle="round", facecolor="white", edgecolor="none", alpha=0.8),
+            )
+
+
+def _plot_dcg_panel(ax: plt.Axes, run_metrics: Mapping[str, object]) -> None:
+    dcg_curve = run_metrics.get("dcg_curve", [])
+    idcg_curve = run_metrics.get("idcg_curve", [])
+    ndcg_curve = run_metrics.get("ndcg_curve_k", [])
+    if not isinstance(dcg_curve, Sequence) or len(dcg_curve) == 0:
+        ax.text(0.5, 0.5, "No DCG data", ha="center", va="center")
+        ax.set_axis_off()
+        return
+
+    ranks = np.arange(1, len(dcg_curve) + 1)
+    ax.plot(ranks, dcg_curve, label="DCG", color="#4c72b0", marker="o")
+    if isinstance(idcg_curve, Sequence) and len(idcg_curve) == len(ranks):
+        ax.plot(ranks, idcg_curve, label="IDCG", color="#55a868", marker="s")
+    ax.set_xlabel("Rank")
+    ax.set_ylabel("Cumulative gain")
+    ax.set_title("Panel B – DCG / IDCG / NDCG")
+
+    ax2 = ax.twinx()
+    if isinstance(ndcg_curve, Sequence) and len(ndcg_curve) == len(ranks):
+        ax2.plot(ranks, ndcg_curve, label="NDCG", color="#c44e52", linestyle="--")
+        ax2.set_ylim(0, 1.05)
+        ax2.set_ylabel("NDCG")
+        final_ndcg = run_metrics.get("ndcg@curve_k")
+        if isinstance(final_ndcg, (int, float)):
+            ax2.text(
+                0.98,
+                0.05,
+                f"NDCG@{len(ranks)} = {final_ndcg:.3f}",
+                transform=ax2.transAxes,
+                ha="right",
+                va="bottom",
+                fontsize=9,
+                bbox=dict(boxstyle="round", facecolor="white", edgecolor="none", alpha=0.8),
+            )
+
+    handles, labels = ax.get_legend_handles_labels()
+    handles2, labels2 = ax2.get_legend_handles_labels()
+    if handles2:
+        handles.extend(handles2)
+        labels.extend(labels2)
+    if handles:
+        ax.legend(handles, labels, loc="upper left")
+
+
+def _plot_reliability_panel(ax: plt.Axes, run_metrics: Mapping[str, object]) -> None:
+    reliability = run_metrics.get("reliability", {})
+    bins = reliability.get("bins") if isinstance(reliability, Mapping) else None
+    mode = reliability.get("mode", "unknown") if isinstance(reliability, Mapping) else "unknown"
+    if not isinstance(bins, Sequence) or len(bins) == 0:
+        ax.text(0.5, 0.5, "Reliability data unavailable", ha="center", va="center")
+        ax.set_axis_off()
+        return
+
+    confidences: List[float] = []
+    precisions: List[float] = []
+    counts: List[int] = []
+    for entry in bins:
+        if not isinstance(entry, Mapping):
+            continue
+        confidences.append(float(entry.get("confidence", 0.0)))
+        precisions.append(float(entry.get("precision", 0.0)))
+        counts.append(int(entry.get("count", 0)))
+
+    if not confidences:
+        ax.text(0.5, 0.5, "Reliability data unavailable", ha="center", va="center")
+        ax.set_axis_off()
+        return
+
+    sizes = 30 + 5 * np.array(counts)
+    ax.plot([0, 1], [0, 1], color="#444444", linestyle="--", linewidth=1, label="Perfect calibration")
+    ax.scatter(confidences, precisions, s=sizes, color="#4c72b0", alpha=0.8, label="Bins")
+    for conf, prec, count in zip(confidences, precisions, counts):
+        ax.text(conf, prec, str(count), fontsize=8, ha="center", va="bottom")
+
+    ax.set_xlabel("Confidence")
+    ax.set_ylabel("Precision")
+    ax.set_xlim(0, 1)
+    ax.set_ylim(0, 1)
+    ax.set_title("Panel C – Reliability diagram")
+    ece = run_metrics.get("ece")
+    if isinstance(ece, (int, float)):
+        ax.text(
+            0.02,
+            0.98,
+            f"ECE = {ece:.3f}\nMode = {mode}",
+            transform=ax.transAxes,
+            ha="left",
+            va="top",
+            fontsize=9,
+            bbox=dict(boxstyle="round", facecolor="white", edgecolor="none", alpha=0.8),
+        )
+
+    ax.legend(loc="upper left")
+
+
+def _compute_rank_swaps(
+    df: pd.DataFrame, primary_label: str, baseline_label: Optional[str]
+) -> List[Dict[str, object]]:
+    if baseline_label is None:
+        return []
+    primary_col = f"rank_{primary_label}"
+    baseline_col = f"rank_{baseline_label}"
+    if primary_col not in df.columns or baseline_col not in df.columns:
+        return []
+
+    relevant = df[df.get("relevance_binary", 0) > 0]
+    swaps: List[Dict[str, object]] = []
+    for _, row in relevant.iterrows():
+        baseline_rank = row.get(baseline_col)
+        target_rank = row.get(primary_col)
+        if pd.isna(baseline_rank) or pd.isna(target_rank):
+            continue
+        baseline_rank = int(baseline_rank)
+        target_rank = int(target_rank)
+        label = row.get("adjuvant_label")
+        if pd.isna(label) or label is None or str(label).strip() == "":
+            label = row.get("adjuvant_vo_id", "Adjuvant")
+        swaps.append(
+            {
+                "label": str(label),
+                "baseline_rank": baseline_rank,
+                "target_rank": target_rank,
+                "delta": baseline_rank - target_rank,
+            }
+        )
+
+    swaps.sort(key=lambda item: (item["delta"], -item["target_rank"]), reverse=True)
+    return swaps
+
+
+def _plot_rank_swap_panel(
+    ax: plt.Axes,
+    summary: Mapping[str, object],
+    df: Optional[pd.DataFrame],
+    primary_label: str,
+    baseline_label: Optional[str],
+) -> None:
+    if df is None or baseline_label is None:
+        ax.text(0.5, 0.5, "No comparison data available", ha="center", va="center")
+        ax.set_axis_off()
+        return
+
+    swaps = _compute_rank_swaps(df, primary_label, baseline_label)
+    if not swaps:
+        ax.text(0.5, 0.5, "No relevant adjuvants with baseline ranks", ha="center", va="center")
+        ax.set_axis_off()
+        return
+
+    labels = [item["label"] for item in swaps]
+    deltas = [item["delta"] for item in swaps]
+    y_positions = np.arange(len(labels))
+    colours = ["#1b9e77" if delta > 0 else ("#d95f02" if delta < 0 else "#7570b3") for delta in deltas]
+
+    ax.barh(y_positions, deltas, color=colours)
+    ax.set_yticks(y_positions)
+    ax.set_yticklabels(labels)
+    ax.set_xlabel("Δ rank (baseline − target)")
+    ax.axvline(0, color="#444444", linewidth=1)
+    ax.invert_yaxis()
+    ax.set_title("Panel D – Rank swap ablation")
+
+    for idx, delta in enumerate(deltas):
+        ax.text(
+            delta,
+            idx,
+            f" {delta:+d}",
+            ha="left" if delta >= 0 else "right",
+            va="center",
+            color="black",
+        )
+
+    delta_ndcg = summary.get("delta_ndcg")
+    if isinstance(delta_ndcg, Mapping) and delta_ndcg:
+        lines = [f"{key}: {value:+.3f}" for key, value in sorted(delta_ndcg.items())]
+        ax.text(
+            0.98,
+            0.02,
+            "\n".join(lines),
+            transform=ax.transAxes,
+            ha="right",
+            va="bottom",
+            fontsize=9,
+            bbox=dict(boxstyle="round", facecolor="white", edgecolor="none", alpha=0.8),
+        )
+
+
+def create_case_study_panels(
+    summary_path: Path,
+    output_path: Path,
+    candidates_csv: Optional[Path] = None,
+    primary_label: str = "target",
+    baseline_label: Optional[str] = "baseline",
+) -> Path:
+    with Path(summary_path).open("r", encoding="utf-8") as handle:
+        summary = json.load(handle)
+    if not isinstance(summary, MutableMapping):
+        raise TypeError("Summary JSON must contain a mapping at the top level.")
+
+    run_metrics = _ensure_run(summary, primary_label)
+    if baseline_label is not None:
+        try:
+            _ensure_run(summary, baseline_label)
+        except KeyError:
+            baseline_label = None
+
+    df: Optional[pd.DataFrame] = None
+    if candidates_csv is not None and Path(candidates_csv).exists():
+        df = pd.read_csv(candidates_csv)
+
+    fig, axes = plt.subplots(2, 2, figsize=(11, 8.5))
+    ax_topk, ax_dcg, ax_rel, ax_rank = axes.flatten()
+
+    _plot_topk_panel(ax_topk, run_metrics)
+    _plot_dcg_panel(ax_dcg, run_metrics)
+    _plot_reliability_panel(ax_rel, run_metrics)
+    _plot_rank_swap_panel(ax_rank, summary, df, primary_label, baseline_label)
+
+    disease = summary.get("disease_key", "Unknown disease")
+    fig.suptitle(f"Case study panels – {disease}")
+    fig.tight_layout(rect=(0, 0, 1, 0.96))
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output_path, dpi=300)
+    plt.close(fig)
+    return output_path
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--summary-json",
+        type=Path,
+        required=True,
+        help="Metrics summary JSON produced by export_case_study.py",
+    )
+    parser.add_argument(
+        "--candidates-csv",
+        type=Path,
+        default=None,
+        help="Candidate table CSV produced by export_case_study.py",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="Destination image path (PNG, PDF, etc.)",
+    )
+    parser.add_argument(
+        "--primary-label",
+        type=str,
+        default="target",
+        help="Label of the primary run inside the summary JSON",
+    )
+    parser.add_argument(
+        "--baseline-label",
+        type=str,
+        default="baseline",
+        help="Optional label of the comparison run for Panel D",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    baseline_label: Optional[str] = args.baseline_label
+    if baseline_label is not None and baseline_label.strip() == "":
+        baseline_label = None
+    create_case_study_panels(
+        summary_path=args.summary_json,
+        output_path=args.output,
+        candidates_csv=args.candidates_csv,
+        primary_label=args.primary_label,
+        baseline_label=baseline_label,
+    )
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/export_case_study.py
+++ b/src/export_case_study.py
@@ -7,12 +7,13 @@ import json
 import math
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Mapping, MutableMapping, Optional, Sequence, Tuple
+from typing import Dict, List, Mapping, MutableMapping, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import pandas as pd
 import torch
-from torch import Tensor
+import torch.nn.functional as F
+from torch import Tensor, nn
 
 from train_disease_ranker import (  # type: ignore
     DEFAULT_TEXT_ENCODER_MAX_LENGTHS,
@@ -42,6 +43,50 @@ class ReliabilityBin:
     confidence: float
     precision: float
     count: int
+
+
+class LegacyListNetRanker(nn.Module):
+    """Dot-product ranking head used by the original ``train_ranker.py`` script."""
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    @staticmethod
+    def _dot_product(query: Tensor, candidates: Tensor) -> Tensor:
+        if query.dim() == 2 and candidates.dim() == 3:
+            expanded = query.unsqueeze(1).expand_as(candidates)
+            return (expanded * candidates).sum(dim=-1)
+        return (query * candidates).sum(dim=-1)
+
+    def score_vax(self, h_vax: Tensor, h_adj: Tensor) -> Tensor:
+        return self._dot_product(h_vax, h_adj)
+
+    def score_dis(
+        self, h_dis: Tensor, h_adj: Tensor, mech_vec: Optional[Tensor] = None
+    ) -> Tensor:
+        del mech_vec  # Legacy head ignores mechanism cues entirely.
+        return self._dot_product(h_dis, h_adj)
+
+    def forward(
+        self,
+        embeddings: Mapping[str, Tensor],
+        vaccine_indices: Tensor,
+        candidate_indices: Tensor,
+        relevance: Tensor,
+    ) -> Tuple[Tensor, Tensor]:
+        vaccine_repr = embeddings["vaccine"][vaccine_indices]
+        adjuvant_repr = embeddings["adjuvant"][candidate_indices]
+        scores = self.score_vax(vaccine_repr, adjuvant_repr)
+
+        positive_mask = (relevance > 0).float()
+        positive_mass = positive_mask.sum(dim=1, keepdim=True).clamp_min(1e-9)
+        target_distribution = positive_mask / positive_mass
+        log_probs = F.log_softmax(scores, dim=1)
+        loss = -(target_distribution * log_probs).sum(dim=1).mean()
+        return loss, scores
+
+
+RankerModule = Union[DualRanker, LegacyListNetRanker]
 
 
 def parse_args() -> argparse.Namespace:
@@ -175,11 +220,43 @@ def _prepare_text_encoder(ckpt_args: Mapping[str, object], device: torch.device)
 
 def _load_checkpoint(path: Path) -> MutableMapping[str, object]:
     checkpoint = torch.load(path, map_location="cpu")
-    required_keys = {"state_dict", "ranking_head_state_dict", "args"}
+
+    # Backwards compatibility for checkpoints produced before DualRanker support.
+    # Older files bundled every parameter under ``state_dict`` (including the
+    # ranking head) or stored the model weights under ``model_state_dict``.
+    if "state_dict" not in checkpoint and "model_state_dict" in checkpoint:
+        checkpoint["state_dict"] = checkpoint.pop("model_state_dict")
+
+    if "ranking_head_state_dict" not in checkpoint:
+        state = checkpoint.get("state_dict")
+        if isinstance(state, Mapping):
+            prefix = "ranking_head."
+            ranking_keys = [key for key in state if key.startswith(prefix)]
+            if ranking_keys:
+                checkpoint["ranking_head_state_dict"] = {
+                    key[len(prefix) :]: state[key]
+                    for key in ranking_keys
+                }
+                for key in ranking_keys:
+                    del state[key]
+
+    legacy_head = "ranking_head_state_dict" not in checkpoint
+    checkpoint["_legacy_listnet_head"] = legacy_head
+
+    required_keys = {"state_dict", "args"}
     missing = required_keys - checkpoint.keys()
     if missing:
         missing_str = ", ".join(sorted(missing))
-        raise KeyError(f"Checkpoint at {path} is missing required keys: {missing_str}")
+        raise KeyError(
+            "Checkpoint at "
+            f"{path} is missing required keys: {missing_str}. "
+            "The file was likely produced by an outdated training script."
+        )
+    if not legacy_head and "ranking_head_state_dict" not in checkpoint:
+        raise KeyError(
+            "Checkpoint at "
+            f"{path} is missing 'ranking_head_state_dict' despite recovery attempts."
+        )
     return checkpoint
 
 
@@ -188,7 +265,7 @@ def _build_model(
     ckpt_args: Mapping[str, object],
     checkpoint: Mapping[str, object],
     device: torch.device,
-) -> Tuple[PyGHeteroEncoder, DualRanker, Optional[Tensor]]:
+) -> Tuple[PyGHeteroEncoder, RankerModule, Optional[Tensor]]:
     node_feat_dims = {nt: graph[nt].x.size(1) for nt in graph.node_types}
     model = PyGHeteroEncoder(
         node_feat_dims,
@@ -208,12 +285,20 @@ def _build_model(
     mech_dim = int(structured.size(1)) if isinstance(structured, Tensor) else 0
     use_mech = bool(ckpt_args.get("enable_disease_mechanism_cues", False)) and mech_dim > 0
     mech_in_dim = mech_dim if use_mech else None
-    ranking_head = DualRanker(
-        int(ckpt_args.get("hidden_dim", 128)),
-        mech_in_dim,
-        float(ckpt_args.get("gamma_mech", 0.3)),
-    )
-    ranking_head.load_state_dict(checkpoint["ranking_head_state_dict"])
+    legacy_head = bool(checkpoint.get("_legacy_listnet_head", False))
+    if legacy_head:
+        print(
+            "Warning: checkpoint lacks a dedicated ranking head; using legacy "
+            "dot-product scores (disease ranking quality may degrade)."
+        )
+        ranking_head: RankerModule = LegacyListNetRanker()
+    else:
+        ranking_head = DualRanker(
+            int(ckpt_args.get("hidden_dim", 128)),
+            mech_in_dim,
+            float(ckpt_args.get("gamma_mech", 0.3)),
+        )
+        ranking_head.load_state_dict(checkpoint["ranking_head_state_dict"])
     ranking_head = ranking_head.to(device)
     ranking_head.eval()
 
@@ -228,7 +313,7 @@ def _score_disease(
     disease_idx: int,
     candidate_ids: Sequence[int],
     model: PyGHeteroEncoder,
-    ranking_head: DualRanker,
+    ranking_head: RankerModule,
     graph: "HeteroData",
     adjuvant_mechanism: Optional[Tensor],
     device: torch.device,

--- a/src/export_case_study.py
+++ b/src/export_case_study.py
@@ -158,7 +158,16 @@ def parse_args() -> argparse.Namespace:
         "--reliability-bins",
         type=int,
         default=10,
-        help="Number of equal-width bins for the reliability diagram.",
+        help="Number of bins for the reliability diagram.",
+    )
+    parser.add_argument(
+        "--reliability-binning",
+        choices=("equal_width", "quantile"),
+        default="equal_width",
+        help=(
+            "Binning strategy for reliability diagram: equal-width score intervals or "
+            "quantile bins with comparable sample counts."
+        ),
     )
     parser.add_argument(
         "--score-normalization",
@@ -400,9 +409,10 @@ def _compute_reliability(
     positives: Sequence[int],
     bins: int,
     normalisation: str,
-) -> Tuple[List[ReliabilityBin], float]:
+    binning: str,
+) -> Tuple[List[ReliabilityBin], float, str]:
     if bins <= 0 or scores.size == 0:
-        return [], 0.0
+        return [], 0.0, "equal_width"
 
     if normalisation == "sigmoid":
         norm_scores = 1.0 / (1.0 + np.exp(-scores))
@@ -418,7 +428,18 @@ def _compute_reliability(
     counts = np.zeros(bins, dtype=int)
     confs = np.zeros(bins, dtype=float)
     precs = np.zeros(bins, dtype=float)
-    edges = np.linspace(0.0, 1.0, bins + 1)
+    applied_mode = "equal_width" if binning != "quantile" else "quantile"
+    if binning == "quantile" and scores.size >= 2 and bins > 1:
+        quantiles = np.linspace(0.0, 1.0, bins + 1)
+        edges = np.quantile(norm_scores, quantiles)
+        edges[0] = float(norm_scores.min())
+        edges[-1] = float(norm_scores.max())
+        if np.any(np.diff(edges) <= 1e-8):
+            edges = np.linspace(0.0, 1.0, bins + 1)
+            applied_mode = "equal_width"
+    else:
+        edges = np.linspace(0.0, 1.0, bins + 1)
+        applied_mode = "equal_width"
     bin_indices = np.digitize(norm_scores, edges, right=False) - 1
     bin_indices = np.clip(bin_indices, 0, bins - 1)
 
@@ -452,7 +473,7 @@ def _compute_reliability(
             )
         )
         ece += (count / total) * abs(precision - confidence)
-    return reliability, float(ece)
+    return reliability, float(ece), applied_mode
 
 
 def _compute_run_metrics(
@@ -464,6 +485,10 @@ def _compute_run_metrics(
     curve_k: int,
     reliability_bins: int,
     normalisation: str,
+    reliability_binning: str,
+    adjuvant_mapping: Mapping[int, str],
+    display_lookup: Mapping[str, str],
+    class_lookup: Mapping[str, str],
 ) -> Dict[str, object]:
     ranked_indices = [int(candidate_ids[i]) for i in run.order]
     metrics: Dict[str, object] = {
@@ -472,7 +497,13 @@ def _compute_run_metrics(
         "num_positives": len(positives),
     }
 
+    score_lookup = {
+        int(candidate_ids[i]): float(run.scores[i]) for i in range(len(candidate_ids))
+    }
+    positives_set = set(positives)
+
     per_k: Dict[str, Dict[str, float]] = {}
+    random_multipliers: Dict[str, Optional[float]] = {}
     for k in topk:
         ranked_slice = ranked_indices[:k]
         per_k[str(k)] = {
@@ -480,14 +511,18 @@ def _compute_run_metrics(
             "recall": _recall_at_k(ranked_slice, positives, k),
             "ndcg": _ndcg_at_k(ranked_slice, gains, positives, k),
         }
+        baseline = k / len(candidate_ids) if len(candidate_ids) > 0 else 0.0
+        if baseline > 0:
+            random_multipliers[str(k)] = per_k[str(k)]["recall"] / baseline
+        else:
+            random_multipliers[str(k)] = None
     metrics["topk"] = per_k
+    metrics["random_recall_multiplier"] = random_multipliers
 
     curve_limit = min(curve_k, len(candidate_ids))
-    dcg_curve = []
-    idcg_curve = []
+    dcg_curve: List[float] = []
+    idcg_curve: List[float] = []
     sorted_gains = sorted(gains.values(), reverse=True)
-    if not sorted_gains:
-        sorted_gains = []
     cumulative_dcg = 0.0
     for idx, candidate in enumerate(ranked_indices[:curve_limit], start=1):
         cumulative_dcg += float(gains.get(candidate, 0.0)) / math.log2(idx + 1)
@@ -499,29 +534,62 @@ def _compute_run_metrics(
         idcg_curve.append(cumulative_idcg)
     metrics["dcg_curve"] = dcg_curve
     metrics["idcg_curve"] = idcg_curve
-    ndcg_at_curve = _ndcg_value(cumulative_dcg, cumulative_idcg)
-    metrics["ndcg@curve_k"] = ndcg_at_curve
+    metrics["ndcg@curve_k"] = _ndcg_value(cumulative_dcg, cumulative_idcg)
+    metrics["ndcg_curve_k"] = [
+        _ndcg_value(dcg_curve[i], idcg_curve[i]) if idcg_curve[i] > 0 else 0.0
+        for i in range(len(dcg_curve))
+    ]
 
-    reliability, ece = _compute_reliability(
+    reliability, ece, applied_binning = _compute_reliability(
         run.scores,
         candidate_ids,
         positives,
         reliability_bins,
         normalisation,
+        reliability_binning,
     )
     metrics["ece"] = ece
-    metrics["reliability_bins"] = [
-        {
-            "lower": bin.lower,
-            "upper": bin.upper,
-            "confidence": bin.confidence,
-            "precision": bin.precision,
-            "count": bin.count,
-        }
-        for bin in reliability
-    ]
-    return metrics
+    metrics["reliability"] = {
+        "mode": applied_binning,
+        "bins": [
+            {
+                "lower": bin.lower,
+                "upper": bin.upper,
+                "confidence": bin.confidence,
+                "precision": bin.precision,
+                "count": bin.count,
+            }
+            for bin in reliability
+        ],
+    }
+    metrics["reliability_bins"] = metrics["reliability"]["bins"]
 
+    first_hit_rank: Optional[int] = None
+    if positives_set:
+        ranks = [run.rank_map.get(pos) for pos in positives_set if pos in run.rank_map]
+        if ranks:
+            first_hit_rank = min(ranks)
+    metrics["first_hit_rank"] = first_hit_rank
+    metrics["mrr"] = (1.0 / first_hit_rank) if first_hit_rank is not None else 0.0
+
+    top_list_limit = min(10, len(ranked_indices))
+    topk_list: List[Dict[str, object]] = []
+    for candidate in ranked_indices[:top_list_limit]:
+        adjuvant_id = adjuvant_mapping.get(candidate, str(candidate))
+        adjuvant_str = str(adjuvant_id)
+        topk_list.append(
+            {
+                "adjuvant_id": adjuvant_str,
+                "adjuvant_label": display_lookup.get(adjuvant_str, adjuvant_str),
+                "score": score_lookup.get(candidate),
+                "relevance_binary": int(candidate in positives_set),
+                "relevance_gain": float(gains.get(candidate, 0.0)),
+                "adjuvant_class": class_lookup.get(adjuvant_str, "unknown"),
+            }
+        )
+    metrics["topk_list"] = topk_list
+
+    return metrics
 
 def _ndcg_value(dcg: float, idcg: float) -> float:
     if idcg <= 0.0:
@@ -734,6 +802,7 @@ def main() -> None:
         "num_candidates": len(candidate_list),
         "num_positives": len(positive_indices),
         "runs": {},
+        "reliability_binning": args.reliability_binning,
     }
     for run in runs:
         metrics_summary["runs"][run.label] = _compute_run_metrics(
@@ -745,6 +814,10 @@ def main() -> None:
             int(args.curve_topk),
             int(args.reliability_bins),
             args.score_normalization,
+            args.reliability_binning,
+            adjuvant_mapping,
+            display_lookup,
+            class_lookup,
         )
 
     if comparison_data is not None:

--- a/src/export_case_study.py
+++ b/src/export_case_study.py
@@ -7,7 +7,7 @@ import json
 import math
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Mapping, MutableMapping, Optional, Sequence, Tuple, Union
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -218,6 +218,21 @@ def _prepare_text_encoder(ckpt_args: Mapping[str, object], device: torch.device)
     return (tokenizer, model), config
 
 
+def _looks_like_dual_ranker_checkpoint(args: Mapping[str, object]) -> bool:
+    """Heuristically determine if ``train_disease_ranker.py`` produced the checkpoint."""
+
+    # The dual-ranker script introduces several disease-specific hyperparameters that
+    # never existed in the original ``train_ranker.py`` CLI.  Presence of any of these
+    # keys therefore implies the checkpoint *should* contain a dedicated ranking head.
+    dual_ranker_keys: Iterable[str] = (
+        "lambda_disease",
+        "disease_ndcg_weight",
+        "disease_listnet_weight",
+        "disease_batch_size",
+    )
+    return any(key in args for key in dual_ranker_keys)
+
+
 def _load_checkpoint(path: Path) -> MutableMapping[str, object]:
     checkpoint = torch.load(path, map_location="cpu")
 
@@ -240,9 +255,6 @@ def _load_checkpoint(path: Path) -> MutableMapping[str, object]:
                 for key in ranking_keys:
                     del state[key]
 
-    legacy_head = "ranking_head_state_dict" not in checkpoint
-    checkpoint["_legacy_listnet_head"] = legacy_head
-
     required_keys = {"state_dict", "args"}
     missing = required_keys - checkpoint.keys()
     if missing:
@@ -252,6 +264,21 @@ def _load_checkpoint(path: Path) -> MutableMapping[str, object]:
             f"{path} is missing required keys: {missing_str}. "
             "The file was likely produced by an outdated training script."
         )
+    args = checkpoint.get("args", {})
+    if not isinstance(args, Mapping):
+        args = {}
+
+    legacy_head = "ranking_head_state_dict" not in checkpoint
+    if legacy_head and _looks_like_dual_ranker_checkpoint(args):
+        raise KeyError(
+            "Checkpoint at "
+            f"{path} was produced by train_disease_ranker.py but is missing "
+            "'ranking_head_state_dict'. The run likely failed before saving the "
+            "disease head; please re-train to generate a complete checkpoint."
+        )
+
+    checkpoint["_legacy_listnet_head"] = legacy_head
+
     if not legacy_head and "ranking_head_state_dict" not in checkpoint:
         raise KeyError(
             "Checkpoint at "

--- a/tests/test_case_study_panels.py
+++ b/tests/test_case_study_panels.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+from analysis.draw_case_study_panels import _compute_rank_swaps, create_case_study_panels
+
+
+def _build_sample_summary(tmp_path: Path) -> Path:
+    summary = {
+        "disease_key": "COVID-19",
+        "runs": {
+            "target": {
+                "topk": {
+                    "5": {"precision": 0.2, "recall": 0.2, "ndcg": 0.3},
+                    "10": {"precision": 0.1, "recall": 0.5, "ndcg": 0.4},
+                },
+                "dcg_curve": [1.0, 1.2, 1.2, 1.2, 1.2],
+                "idcg_curve": [1.0, 1.5, 1.7, 1.8, 1.9],
+                "ndcg@curve_k": 0.632,
+                "ndcg_curve_k": [1.0, 0.8, 0.71, 0.66, 0.63],
+                "ece": 0.073,
+                "reliability": {
+                    "mode": "equal_width",
+                    "bins": [
+                        {"lower": 0.0, "upper": 0.33, "confidence": 0.1, "precision": 0.0, "count": 2},
+                        {"lower": 0.33, "upper": 0.66, "confidence": 0.55, "precision": 0.5, "count": 3},
+                        {"lower": 0.66, "upper": 1.0, "confidence": 0.8, "precision": 1.0, "count": 1},
+                    ],
+                },
+                "topk_list": [
+                    {
+                        "adjuvant_id": "Adj-1",
+                        "adjuvant_label": "Adj 1",
+                        "score": 0.91,
+                        "relevance_binary": 1,
+                    },
+                    {
+                        "adjuvant_id": "Adj-2",
+                        "adjuvant_label": "Adj 2",
+                        "score": 0.65,
+                        "relevance_binary": 0,
+                    },
+                    {
+                        "adjuvant_id": "Adj-3",
+                        "adjuvant_label": "Adj 3",
+                        "score": 0.5,
+                        "relevance_binary": 0,
+                    },
+                ],
+            },
+            "baseline": {
+                "topk": {
+                    "5": {"precision": 0.0, "recall": 0.0, "ndcg": 0.1},
+                    "10": {"precision": 0.1, "recall": 0.3, "ndcg": 0.2},
+                },
+                "dcg_curve": [0.5, 0.5, 0.5, 0.5, 0.5],
+                "idcg_curve": [1.0, 1.5, 1.7, 1.8, 1.9],
+                "ndcg@curve_k": 0.26,
+                "ndcg_curve_k": [0.5, 0.33, 0.29, 0.27, 0.26],
+                "ece": 0.15,
+                "reliability": {
+                    "mode": "equal_width",
+                    "bins": [
+                        {"lower": 0.0, "upper": 0.33, "confidence": 0.15, "precision": 0.0, "count": 2},
+                        {"lower": 0.33, "upper": 0.66, "confidence": 0.5, "precision": 0.3, "count": 3},
+                        {"lower": 0.66, "upper": 1.0, "confidence": 0.7, "precision": 0.6, "count": 1},
+                    ],
+                },
+                "topk_list": [],
+            },
+        },
+        "delta_ndcg": {"ndcg@5": 0.2, "ndcg@10": 0.2},
+    }
+    summary_path = tmp_path / "summary.json"
+    with summary_path.open("w", encoding="utf-8") as handle:
+        json.dump(summary, handle)
+    return summary_path
+
+
+def _build_sample_csv(tmp_path: Path) -> Path:
+    df = pd.DataFrame(
+        [
+            {
+                "adjuvant_vo_id": "Adj-1",
+                "adjuvant_label": "Adj 1",
+                "rank_target": 1,
+                "rank_baseline": 4,
+                "relevance_binary": 1,
+            },
+            {
+                "adjuvant_vo_id": "Adj-2",
+                "adjuvant_label": "Adj 2",
+                "rank_target": 2,
+                "rank_baseline": 2,
+                "relevance_binary": 1,
+            },
+            {
+                "adjuvant_vo_id": "Adj-3",
+                "adjuvant_label": "Adj 3",
+                "rank_target": 3,
+                "rank_baseline": 3,
+                "relevance_binary": 0,
+            },
+        ]
+    )
+    csv_path = tmp_path / "candidates.csv"
+    df.to_csv(csv_path, index=False)
+    return csv_path
+
+
+def test_compute_rank_swaps_orders_by_improvement(tmp_path: Path) -> None:
+    csv_path = _build_sample_csv(tmp_path)
+    df = pd.read_csv(csv_path)
+    swaps = _compute_rank_swaps(df, primary_label="target", baseline_label="baseline")
+    assert [entry["label"] for entry in swaps] == ["Adj 1", "Adj 2"]
+    assert swaps[0]["delta"] == 3
+    assert swaps[1]["delta"] == 0
+
+
+def test_create_case_study_panels_writes_image(tmp_path: Path) -> None:
+    summary_path = _build_sample_summary(tmp_path)
+    csv_path = _build_sample_csv(tmp_path)
+    output_path = tmp_path / "figure.png"
+
+    create_case_study_panels(
+        summary_path=summary_path,
+        output_path=output_path,
+        candidates_csv=csv_path,
+        primary_label="target",
+        baseline_label="baseline",
+    )
+
+    assert output_path.exists()
+    assert output_path.stat().st_size > 0

--- a/tests/test_export_case_study_legacy.py
+++ b/tests/test_export_case_study_legacy.py
@@ -96,3 +96,23 @@ def test_legacy_checkpoint_falls_back_to_dot_product(monkeypatch, tmp_path, caps
     assert isinstance(model, DummyEncoder)
     assert model.state_loaded is True
     assert adjuvant_mechanism is None
+
+
+def test_dual_ranker_checkpoint_without_head_errors(tmp_path):
+    """Modern checkpoints should refuse to load if the ranking head is missing."""
+
+    ckpt_path = tmp_path / "broken.pt"
+    dual_args = {
+        "data_path": "dummy.csv",
+        "hidden_dim": 8,
+        "lambda_disease": 0.5,
+        "disease_ndcg_weight": 1.0,
+    }
+    torch.save({"state_dict": {}, "args": dual_args}, ckpt_path)
+
+    with pytest.raises(KeyError) as err:
+        ecs._load_checkpoint(ckpt_path)
+
+    message = str(err.value)
+    assert "train_disease_ranker.py" in message
+    assert "ranking_head_state_dict" in message

--- a/tests/test_export_case_study_legacy.py
+++ b/tests/test_export_case_study_legacy.py
@@ -19,6 +19,8 @@ if str(SRC_DIR) not in sys.path:
 
 import export_case_study as ecs  # noqa: E402
 
+np = ecs.np
+
 
 class DummyGraph:
     """Minimal stand-in for the PyG HeteroData object."""
@@ -116,3 +118,89 @@ def test_dual_ranker_checkpoint_without_head_errors(tmp_path):
     message = str(err.value)
     assert "train_disease_ranker.py" in message
     assert "ranking_head_state_dict" in message
+
+
+def test_compute_reliability_quantile_and_equal_width():
+    scores = np.array([0.0, 1.0, 2.0, 3.0], dtype=float)
+    candidate_ids = [0, 1, 2, 3]
+    positives = [0, 2]
+
+    quantile_bins, quantile_ece, mode = ecs._compute_reliability(
+        scores,
+        candidate_ids,
+        positives,
+        bins=2,
+        normalisation="minmax",
+        binning="quantile",
+    )
+    assert mode == "quantile"
+    assert [bin.count for bin in quantile_bins] == [2, 2]
+    assert pytest.approx(quantile_ece, rel=1e-4) == 1 / 3
+
+    width_bins, width_ece, mode_width = ecs._compute_reliability(
+        scores,
+        candidate_ids,
+        positives,
+        bins=2,
+        normalisation="minmax",
+        binning="equal_width",
+    )
+    assert mode_width == "equal_width"
+    assert [bin.count for bin in width_bins] == [2, 2]
+    assert pytest.approx(width_ece, rel=1e-4) == pytest.approx(quantile_ece)
+
+
+def test_compute_reliability_quantile_fallback():
+    scores = np.array([0.5, 0.5, 0.5], dtype=float)
+    candidate_ids = [0, 1, 2]
+    positives = [1]
+
+    bins, ece, mode = ecs._compute_reliability(
+        scores,
+        candidate_ids,
+        positives,
+        bins=3,
+        normalisation="minmax",
+        binning="quantile",
+    )
+    assert mode == "equal_width"
+    assert sum(bin.count for bin in bins) == len(scores)
+    assert ece == pytest.approx(0.0)
+
+
+def test_compute_run_metrics_enrichments():
+    scores = np.array([0.9, 0.8, 0.2, 0.1], dtype=float)
+    candidate_ids = [0, 1, 2, 3]
+    order = np.array([0, 1, 2, 3], dtype=int)
+    rank_map = {candidate_ids[idx]: idx + 1 for idx in range(len(candidate_ids))}
+    run = ecs.RunOutputs(label="primary", scores=scores, order=order, rank_map=rank_map)
+
+    positives = [0, 2]
+    gains = {0: 1.0, 2: 1.0}
+    adjuvant_mapping = {idx: f"A{idx}" for idx in candidate_ids}
+    display_lookup = {f"A{idx}": f"Adj {idx}" for idx in candidate_ids}
+    class_lookup = {f"A{idx}": f"cls{idx}" for idx in candidate_ids}
+
+    metrics = ecs._compute_run_metrics(
+        run,
+        candidate_ids,
+        positives,
+        gains,
+        topk=(1, 3),
+        curve_k=4,
+        reliability_bins=2,
+        normalisation="minmax",
+        reliability_binning="equal_width",
+        adjuvant_mapping=adjuvant_mapping,
+        display_lookup=display_lookup,
+        class_lookup=class_lookup,
+    )
+
+    assert metrics["first_hit_rank"] == 1
+    assert metrics["mrr"] == pytest.approx(1.0)
+    assert metrics["reliability"]["mode"] == "equal_width"
+    assert len(metrics["ndcg_curve_k"]) == 4
+    assert metrics["topk_list"][0]["adjuvant_id"] == "A0"
+    assert metrics["topk_list"][0]["relevance_binary"] == 1
+    assert metrics["topk_list"][1]["relevance_binary"] == 0
+    assert metrics["random_recall_multiplier"]["3"] == pytest.approx(4 / 3)

--- a/tests/test_export_case_study_legacy.py
+++ b/tests/test_export_case_study_legacy.py
@@ -1,0 +1,98 @@
+"""Regression check for loading legacy train_ranker checkpoints."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+# Ensure the repository root and src directory are on the import path.
+ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = ROOT / "src"
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+import export_case_study as ecs  # noqa: E402
+
+
+class DummyGraph:
+    """Minimal stand-in for the PyG HeteroData object."""
+
+    node_types = ("disease", "adjuvant")
+
+    def __init__(self, feat_dim: int = 8, mech_dim: int = 0) -> None:
+        adjuvant_structured = (
+            torch.zeros(3, mech_dim, dtype=torch.float32) if mech_dim > 0 else None
+        )
+        self._nodes = {
+            "disease": SimpleNamespace(x=torch.zeros(2, feat_dim, dtype=torch.float32)),
+            "adjuvant": SimpleNamespace(
+                x=torch.zeros(4, feat_dim, dtype=torch.float32), structured=adjuvant_structured
+            ),
+        }
+
+    def __getitem__(self, key: str) -> SimpleNamespace:
+        return self._nodes[key]
+
+    def metadata(self) -> tuple:
+        return (list(self.node_types), [("disease", "rel", "adjuvant")])
+
+
+class DummyEncoder:
+    """Tracks whether ``load_state_dict`` was called."""
+
+    last_instance: "DummyEncoder | None" = None
+
+    def __init__(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
+        self.state_loaded = False
+        DummyEncoder.last_instance = self
+
+    def load_state_dict(self, state):  # type: ignore[no-untyped-def]
+        self.state_loaded = True
+        self.state = state
+
+    def to(self, device):  # type: ignore[no-untyped-def]
+        return self
+
+    def eval(self):  # type: ignore[no-untyped-def]
+        return self
+
+
+class FailingDualRanker:
+    def __init__(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
+        raise AssertionError("Modern DualRanker should not be constructed for legacy checkpoints")
+
+
+def test_legacy_checkpoint_falls_back_to_dot_product(monkeypatch, tmp_path, capsys):
+    """Exporter should accept the legacy checkpoint layout and emit a warning."""
+
+    ckpt_path = tmp_path / "legacy.pt"
+    legacy_args = {"data_path": "dummy.csv", "hidden_dim": 8}
+    legacy_state = {"encoder.weight": torch.zeros(1)}
+    torch.save({"state_dict": legacy_state, "args": legacy_args}, ckpt_path)
+
+    checkpoint = ecs._load_checkpoint(ckpt_path)
+    assert checkpoint["_legacy_listnet_head"] is True
+
+    monkeypatch.setattr(ecs, "PyGHeteroEncoder", DummyEncoder)
+    monkeypatch.setattr(ecs, "DualRanker", FailingDualRanker)
+
+    graph = DummyGraph()
+    model, ranking_head, adjuvant_mechanism = ecs._build_model(
+        graph,
+        checkpoint["args"],
+        checkpoint,
+        torch.device("cpu"),
+    )
+
+    captured = capsys.readouterr()
+    assert "legacy dot-product" in captured.out
+    assert isinstance(ranking_head, ecs.LegacyListNetRanker)
+    assert isinstance(model, DummyEncoder)
+    assert model.state_loaded is True
+    assert adjuvant_mechanism is None


### PR DESCRIPTION
## Summary
- add a LegacyListNetRanker implementation and checkpoint tagging so the exporter recognises missing ranking heads
- update model construction to warn and fall back to the legacy scorer when needed
- add a regression test that exercises the legacy path via a mocked graph/encoder

## Testing
- pytest tests/test_export_case_study_legacy.py (skipped: torch)

------
https://chatgpt.com/codex/tasks/task_e_68ee4d78ac548321adf4242d17914978

## Summary by Sourcery

Implement backward compatibility for legacy train_ranker checkpoints by extracting or inferring old ranking head parameters, flagging legacy models, and falling back to a new LegacyListNetRanker with appropriate warnings.

New Features:
- Add LegacyListNetRanker for dot-product ranking and fallback handling for legacy checkpoints
- Enhance checkpoint loader to recover or infer ranking_head_state_dict and flag legacy checkpoints
- Update model construction to warn and instantiate LegacyListNetRanker when loading legacy checkpoints

Tests:
- Add regression test to verify legacy checkpoint loading and fallback path with mocked encoder and ranking head